### PR TITLE
chore(evals): replace deprecated Cerebras model with gpt-oss-120b

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -42,11 +42,11 @@ Run `npm install` once before running evals locally.
 
 Current models:
 
-| Role          | When                        | Provider                                      | Model ID                                  |
-| ------------- | --------------------------- | --------------------------------------------- | ----------------------------------------- |
-| Generator     | All runs                    | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:gpt-oss-120b`                   |
-| Judge (CI)    | CI only                     | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:gpt-oss-120b`                   |
-| Judge (local) | Optional — stronger quality | [Google Gemini](https://aistudio.google.com/) | `google:gemini-2.5-flash-lite`            |
+| Role          | When                        | Provider                                      | Model ID                       |
+| ------------- | --------------------------- | --------------------------------------------- | ------------------------------ |
+| Generator     | All runs                    | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:gpt-oss-120b`        |
+| Judge (CI)    | CI only                     | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:gpt-oss-120b`        |
+| Judge (local) | Optional — stronger quality | [Google Gemini](https://aistudio.google.com/) | `google:gemini-2.5-flash-lite` |
 
 Skill eval YAMLs reference these IDs directly. When models change, update this table
 and the model IDs in the YAML files and CI workflows.

--- a/evals/README.md
+++ b/evals/README.md
@@ -44,8 +44,8 @@ Current models:
 
 | Role          | When                        | Provider                                      | Model ID                                  |
 | ------------- | --------------------------- | --------------------------------------------- | ----------------------------------------- |
-| Generator     | All runs                    | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:qwen-3-235b-a22b-instruct-2507` |
-| Judge (CI)    | CI only                     | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:qwen-3-235b-a22b-instruct-2507` |
+| Generator     | All runs                    | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:gpt-oss-120b`                   |
+| Judge (CI)    | CI only                     | [Cerebras](https://inference.cerebras.ai/)    | `cerebras:gpt-oss-120b`                   |
 | Judge (local) | Optional — stronger quality | [Google Gemini](https://aistudio.google.com/) | `google:gemini-2.5-flash-lite`            |
 
 Skill eval YAMLs reference these IDs directly. When models change, update this table

--- a/evals/prompts/TEMPLATE.yaml
+++ b/evals/prompts/TEMPLATE.yaml
@@ -33,7 +33,7 @@ defaultTest:
   vars:
     skillFile: skills/maplibre-your-skill-name/SKILL.md
   options:
-    provider: cerebras:qwen-3-235b-a22b-instruct-2507
+    provider: cerebras:gpt-oss-120b
 
 # Write exactly 4 tests per skill — one of each type:
 #   1. Explicit   — names the topic directly

--- a/evals/prompts/maplibre-mapbox-migration.yaml
+++ b/evals/prompts/maplibre-mapbox-migration.yaml
@@ -7,8 +7,8 @@ prompts:
   - file://lib/skill-prompt.mjs
 
 providers:
-  - id: cerebras:qwen-3-235b-a22b-instruct-2507
-    label: cerebras-qwen
+  - id: cerebras:gpt-oss-120b
+    label: cerebras-gpt-oss
 
 evaluateOptions:
   delay: 500
@@ -17,7 +17,7 @@ defaultTest:
   vars:
     skillFile: skills/maplibre-mapbox-migration/SKILL.md
   options:
-    provider: cerebras:qwen-3-235b-a22b-instruct-2507
+    provider: cerebras:gpt-oss-120b
 
 tests:
   - description: explicit — validate style JSON with CLI tool after migration

--- a/evals/prompts/maplibre-pmtiles-patterns.yaml
+++ b/evals/prompts/maplibre-pmtiles-patterns.yaml
@@ -7,8 +7,8 @@ prompts:
   - file://lib/skill-prompt.mjs
 
 providers:
-  - id: cerebras:qwen-3-235b-a22b-instruct-2507
-    label: cerebras-qwen
+  - id: cerebras:gpt-oss-120b
+    label: cerebras-gpt-oss
 
 evaluateOptions:
   delay: 500
@@ -17,7 +17,7 @@ defaultTest:
   vars:
     skillFile: skills/maplibre-pmtiles-patterns/SKILL.md
   options:
-    provider: cerebras:qwen-3-235b-a22b-instruct-2507
+    provider: cerebras:gpt-oss-120b
 
 tests:
   - description: explicit — loading a PMTiles file in MapLibre

--- a/evals/prompts/maplibre-tile-sources.yaml
+++ b/evals/prompts/maplibre-tile-sources.yaml
@@ -18,8 +18,8 @@ prompts:
   - file://lib/skill-prompt.mjs
 
 providers:
-  - id: cerebras:qwen-3-235b-a22b-instruct-2507
-    label: cerebras-qwen
+  - id: cerebras:gpt-oss-120b
+    label: cerebras-gpt-oss
 
 evaluateOptions:
   delay: 500
@@ -28,7 +28,7 @@ defaultTest:
   vars:
     skillFile: skills/maplibre-tile-sources/SKILL.md
   options:
-    provider: cerebras:qwen-3-235b-a22b-instruct-2507
+    provider: cerebras:gpt-oss-120b
 
 tests:
   - description: explicit — GeoJSON vs tiles decision for a real scenario


### PR DESCRIPTION
## Summary

- Replaces `qwen-3-235b-a22b-instruct-2507` (deprecated May 27, 2026) with
`cerebras:gpt-oss-120b` in all eval YAML configs, TEMPLATE.yaml, and the README
- Verified all three skill evals pass with the new model (with Gemini judge)
- No skill content changes

## Test plan

- [x] All three skill evals pass: maplibre-pmtiles-patterns, maplibre-mapbox-migration,
maplibre-tile-sources
- [x] Baseline (--var injectSkill=false) confirms tests still fail without skill