### PR TITLE
fix(evals): bump eval workflow to Node 22

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts


### PR DESCRIPTION
## Summary

- `promptfoo` now requires Node `>=22.22.0`; `eval.yml`'s "Setup Node.js" step was still pinned to `'20'`, so every eval run — scheduled or `workflow_dispatch` — fails immediately at the `Run evals` step with "promptfoo requires a supported Node.js runtime."
- Bumps `eval.yml` to `node-version: '22'`. `check.yml` is untouched — it never invokes `promptfoo`, so it stays on 20.

## Found via

A `workflow_dispatch` run against #52 (testing #51's token-scoping fix on the old, still-unscoped `eval.yml` on `main`) failed immediately with:

```
promptfoo requires a supported Node.js runtime.
Detected: v20.20.2
Required: >=22.22.0
```

Run: https://github.com/maplibre/maplibre-agent-skills/actions/runs/32795381411

This is unrelated to #51's token scoping, but worth landing on its own since #51 doesn't touch `node-version` — once it merges, the next scheduled run would hit this same failure with zero eval output produced.

## Test plan

- [x] `npm run check` (pre-push hook) passes
- [x] Confirm a `workflow_dispatch` run succeeds past the `Run evals` step with Node 22

## AI usage

Diff drafted with Claude Code (Sonnet 5) from a `workflow_dispatch` run's failure log during review of #51; reviewed and directed by me throughout.

https://claude.ai/code/session_0133ZaGJDWLg3iAF9d5bQQLQ