### PR TITLE
ci(release): version and changelog automation from a PR field

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,18 @@ Read `SKILL.md` to check for factual errors. Skim the corresponding prompt in
 `evals/prompts/` and the summary in `evals/results`
 (the individual CSVs are raw LLM output — only worth it if you want the details).
 
+## Changelog
+
+<!--
+Bump: how this PR should move the version when the next release is cut — `minor` for a new or removed skill or a change to how skills are consumed, `patch` for content fixes and tooling, `major` reserved for a change that invalidates installed skills, `none` for changes that need no CHANGELOG entry (typo fixes, CI-only).
+Entry: one line, in the CHANGELOG's voice, naming the skill if one is touched. Omit when Bump is none.
+Category: Added | Changed | Fixed | Removed | Internal (which CHANGELOG heading the entry goes under).
+-->
+
+Bump: patch
+Category: Changed
+Entry: `maplibre-example`: one-line description of what changed
+
 ## Checks
 
 - [ ] `npm run check` passes

--- a/.github/workflows/changelog-field.yml
+++ b/.github/workflows/changelog-field.yml
@@ -1,0 +1,28 @@
+name: Changelog field
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate changelog field
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-changelog-field.js

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,86 @@
+name: Changelog
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: changelog
+  cancel-in-progress: false
+
+jobs:
+  accrue:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Find the merged PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY_FILE: ${{ runner.temp }}/pr_body.txt
+        run: node scripts/merged-pr.js
+
+      - name: Record the changelog entry
+        if: steps.pr.outputs.found == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_BODY_FILE: ${{ runner.temp }}/pr_body.txt
+        run: |
+          node scripts/accrue-changelog.js
+          npx prettier --write CHANGELOG.md
+
+      - name: Commit
+        if: steps.pr.outputs.found == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore(changelog): record #${PR_NUMBER}"
+          git push
+
+  tag:
+    needs: accrue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for a version change
+        id: version
+        run: node scripts/version-changed.js
+
+      - name: Tag and publish the release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG="v${VERSION}"
+          if [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
+            echo "Tag $TAG already exists — skipping."
+            exit 0
+          fi
+          node scripts/changelog-section.js "$VERSION" > "$RUNNER_TEMP/notes.md"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --notes-file "$RUNNER_TEMP/notes.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description:
+          'Version bump level (auto uses the level recorded from merged PRs)'
+        required: true
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Cut the release
+        id: release
+        env:
+          LEVEL: ${{ inputs.level }}
+        run: node scripts/cut-release.js --level "$LEVEL"
+
+      - name: Open the release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          BRANCH="release/v${VERSION}"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md package.json package-lock.json README.md
+          git commit -m "chore(release): v${VERSION}"
+          git push origin "$BRANCH"
+          node scripts/release-pr-body.js "$VERSION" > "$RUNNER_TEMP/pr-body.md"
+          if ! gh pr create --title "chore(release): v${VERSION}" --body-file "$RUNNER_TEMP/pr-body.md"; then
+            echo "::error::Could not open the release PR. The branch $BRANCH is pushed; open the PR by hand, or enable 'Allow GitHub Actions to create and approve pull requests' under Settings > Actions > General > Workflow permissions and dispatch again."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Notable changes to this repo's skills and tooling. Loosely follows [Keep a Changelog](https://keepachangelog.com/), adapted for a skills repo — skills are additive markdown, so there's no real "breaking change" axis; entries are grouped by what changed, not by semver category.
+Notable changes to this repo's skills and tooling. Loosely follows [Keep a Changelog](https://keepachangelog.com/), adapted for a skills repo — skills are additive markdown, so there's no real "breaking change" axis; entries are grouped by what changed, not by semver category. Entries under [Unreleased] are added automatically from merged PRs.
 
 ## [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,21 @@ All checks pass when the output ends with:
 1. Create a branch: `git checkout -b fix-your-description`
 2. Make your edit, following whichever path in [Ways to contribute](#ways-to-contribute) matches what you're doing.
 3. Run `npm run check`, and evals too if you touched skill content.
-4. Push and open a PR describing what you changed and why.
+4. Push and open a PR describing what you changed and why. Fill in the Changelog section — see [Versioning and the CHANGELOG](#versioning-and-the-changelog).
+
+## Versioning and the CHANGELOG
+
+Every PR includes a `## Changelog` section in its description (the PR template pre-fills it). Fill in three fields:
+
+| Field      | What to write                                                                                                                                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Bump`     | `minor` for a new or removed skill or a change to how skills are consumed; `patch` for content fixes and tooling; `major` if installed skills would break; `none` for typo fixes, CI-only, or changes that need no entry |
+| `Category` | `Added`, `Changed`, `Fixed`, `Removed`, or `Internal` — the CHANGELOG heading the entry goes under                                                                                                                       |
+| `Entry`    | One line in the CHANGELOG's voice, naming the skill if one is touched. Omit when Bump is `none`                                                                                                                          |
+
+A CI check validates the field on every PR. On merge, automation inserts the entry under `[Unreleased]` in `CHANGELOG.md` — do not hand-edit that section. A merged PR without a usable field (one opened before the template carried it, for example) is skipped with a warning on the workflow run, and its entry can be added by hand.
+
+Releases are cut by a maintainer via the Release workflow (`workflow_dispatch`), which bumps the version, moves `[Unreleased]` entries into a dated section, regenerates the README skills table, and opens a release PR. Merging that PR tags `vX.Y.Z` and publishes the GitHub Release. Opening the PR needs "Allow GitHub Actions to create and approve pull requests" enabled under Settings → Actions → General → Workflow permissions; without it the workflow pushes the `release/vX.Y.Z` branch and stops, and the PR can be opened by hand. A PR opened by the workflow does not trigger `check.yml` on its own (GitHub does not run workflows for events caused by `GITHUB_TOKEN`); close and reopen it to run the checks. The README skills table is regenerated at the same time: rows are sorted by name, a row is added for each new skill (its "Use when" text seeded from the `Use when` clause of the skill's `description`), and rows for removed skills are dropped. Existing "Use when" text is preserved, so edit it in place in `README.md` whenever it can be improved; there is no need to touch the table when adding a skill.
 
 ## Note on AI usage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,11 +218,12 @@ All checks pass when the output ends with:
 1. Create a branch: `git checkout -b fix-your-description`
 2. Make your edit, following whichever path in [Ways to contribute](#ways-to-contribute) matches what you're doing.
 3. Run `npm run check`, and evals too if you touched skill content.
-4. Push and open a PR describing what you changed and why. Fill in the Changelog section — see [Versioning and the CHANGELOG](#versioning-and-the-changelog).
+4. Push and open a PR describing what you changed and why.
+5. **Fill in the Changelog section** in your PR description — this is required. A CI check validates it on every PR. See [How to fill in the Changelog field](#how-to-fill-in-the-changelog-field) below.
 
-## Versioning and the CHANGELOG
+### How to fill in the Changelog field
 
-Every PR includes a `## Changelog` section in its description (the PR template pre-fills it). Fill in three fields:
+Every PR description includes a `## Changelog` section (the PR template pre-fills it). Fill in three fields:
 
 | Field      | What to write                                                                                                                                                                                                            |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -230,7 +231,9 @@ Every PR includes a `## Changelog` section in its description (the PR template p
 | `Category` | `Added`, `Changed`, `Fixed`, `Removed`, or `Internal` — the CHANGELOG heading the entry goes under                                                                                                                       |
 | `Entry`    | One line in the CHANGELOG's voice, naming the skill if one is touched. Omit when Bump is `none`                                                                                                                          |
 
-A CI check validates the field on every PR. On merge, automation inserts the entry under `[Unreleased]` in `CHANGELOG.md` — do not hand-edit that section. A merged PR without a usable field (one opened before the template carried it, for example) is skipped with a warning on the workflow run, and its entry can be added by hand.
+On merge, automation reads these fields and inserts the entry under `[Unreleased]` in `CHANGELOG.md` — do not hand-edit that section. A merged PR without a usable field (one opened before the template carried it, for example) is skipped with a warning on the workflow run, and its entry can be added by hand.
+
+### How releases are cut
 
 Releases are cut by a maintainer via the Release workflow (`workflow_dispatch`), which bumps the version, moves `[Unreleased]` entries into a dated section, regenerates the README skills table, and opens a release PR. Merging that PR tags `vX.Y.Z` and publishes the GitHub Release. Opening the PR needs "Allow GitHub Actions to create and approve pull requests" enabled under Settings → Actions → General → Workflow permissions; without it the workflow pushes the `release/vX.Y.Z` branch and stops, and the PR can be opened by hand. A PR opened by the workflow does not trigger `check.yml` on its own (GitHub does not run workflows for events caused by `GITHUB_TOKEN`); close and reopen it to run the checks. The README skills table is regenerated at the same time: rows are sorted by name, a row is added for each new skill (its "Use when" text seeded from the `Use when` clause of the skill's `description`), and rows for removed skills are dropped. Existing "Use when" text is preserved, so edit it in place in `README.md` whenever it can be improved; there is no need to touch the table when adding a skill.
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,19 @@ Note that provisional skills are not necessarily lower quality or less reliable.
 
 Each skill's front matter is the source of truth for its current status — see [What Status Means](#what-status-means).
 
+<!-- skills-table:start -->
+<!-- Rows are regenerated at release by `npm run generate:skills-table`: sorted by name, new skills added, removed skills dropped. Edit the "Use when" text in place; it is preserved. -->
+
 | Skill                                                                    | Use when                                                                                                                             |
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [`maplibre-tile-sources`](skills/maplibre-tile-sources/SKILL.md)         | Choosing how to supply map data; deciding between GeoJSON and tiles; configuring a basemap; debugging blank maps or missing labels   |
-| [`maplibre-pmtiles-patterns`](skills/maplibre-pmtiles-patterns/SKILL.md) | Hosting tiles without a tile server; static or serverless deployments; converting from MBTiles; generating tiles from OSM or GeoJSON |
-| [`maplibre-mapbox-migration`](skills/maplibre-mapbox-migration/SKILL.md) | Moving an existing Mapbox GL JS app to MapLibre; evaluating MapLibre as an open-source alternative                                   |
-| [`maplibre-terrain-patterns`](skills/maplibre-terrain-patterns/SKILL.md) | Adding elevation context, hillshade, or 3D terrain; choosing raster-dem sources and encodings; self-hosting DEM tiles                |
 | [`maplibre-cartography`](skills/maplibre-cartography/SKILL.md)           | Styling a map; making labels, markers, or roads readable on imagery or vector basemaps; setting up fonts, sprites, or shields        |
-| [`maplibre-skill-authoring`](skills/maplibre-skill-authoring/SKILL.md)   | Turning a session where you researched and shipped something MapLibre didn't document into a skill or a failure report               |
+| [`maplibre-mapbox-migration`](skills/maplibre-mapbox-migration/SKILL.md) | Moving an existing Mapbox GL JS app to MapLibre; evaluating MapLibre as an open-source alternative                                   |
+| [`maplibre-pmtiles-patterns`](skills/maplibre-pmtiles-patterns/SKILL.md) | Hosting tiles without a tile server; static or serverless deployments; converting from MBTiles; generating tiles from OSM or GeoJSON |
+| [`maplibre-terrain-patterns`](skills/maplibre-terrain-patterns/SKILL.md) | Adding elevation context, hillshade, or 3D terrain; choosing raster-dem sources and encodings; self-hosting DEM tiles                |
+| [`maplibre-tile-sources`](skills/maplibre-tile-sources/SKILL.md)         | Choosing how to supply map data; deciding between GeoJSON and tiles; configuring a basemap; debugging blank maps or missing labels   |
+| [`maplibre-v6-migration`](skills/maplibre-v6-migration/SKILL.md)         | A v5 app breaks after upgrading to v6, or before pinning a v6 install                                                                |
+
+<!-- skills-table:end -->
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Each skill's front matter is the source of truth for its current status — see 
 <!-- skills-table:start -->
 <!-- Rows are regenerated at release by `npm run generate:skills-table`: sorted by name, new skills added, removed skills dropped. Edit the "Use when" text in place; it is preserved. -->
 
-| Skill                                                                    | Use when                                                                                                                             |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [`maplibre-cartography`](skills/maplibre-cartography/SKILL.md)           | Styling a map; making labels, markers, or roads readable on imagery or vector basemaps; setting up fonts, sprites, or shields        |
-| [`maplibre-mapbox-migration`](skills/maplibre-mapbox-migration/SKILL.md) | Moving an existing Mapbox GL JS app to MapLibre; evaluating MapLibre as an open-source alternative                                   |
-| [`maplibre-pmtiles-patterns`](skills/maplibre-pmtiles-patterns/SKILL.md) | Hosting tiles without a tile server; static or serverless deployments; converting from MBTiles; generating tiles from OSM or GeoJSON |
-| [`maplibre-terrain-patterns`](skills/maplibre-terrain-patterns/SKILL.md) | Adding elevation context, hillshade, or 3D terrain; choosing raster-dem sources and encodings; self-hosting DEM tiles                |
-| [`maplibre-tile-sources`](skills/maplibre-tile-sources/SKILL.md)         | Choosing how to supply map data; deciding between GeoJSON and tiles; configuring a basemap; debugging blank maps or missing labels   |
-| [`maplibre-v6-migration`](skills/maplibre-v6-migration/SKILL.md)         | A v5 app breaks after upgrading to v6, or before pinning a v6 install                                                                |
+| Skill                                                                    | Use when                                                                                                                                                             |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`maplibre-cartography`](skills/maplibre-cartography/SKILL.md)           | Styling a map; making labels, markers, or roads readable on imagery or vector basemaps; setting up fonts, sprites, or shields                                        |
+| [`maplibre-fonts-glyphs`](skills/maplibre-fonts-glyphs/SKILL.md)         | Text labels aren't rendering in the intended font, setting up a glyphs server, choosing between self-hosting and generating font PBFs, or handling non-Latin scripts |
+| [`maplibre-mapbox-migration`](skills/maplibre-mapbox-migration/SKILL.md) | Moving an existing Mapbox GL JS app to MapLibre; evaluating MapLibre as an open-source alternative                                                                   |
+| [`maplibre-pmtiles-patterns`](skills/maplibre-pmtiles-patterns/SKILL.md) | Hosting tiles without a tile server; static or serverless deployments; converting from MBTiles; generating tiles from OSM or GeoJSON                                 |
+| [`maplibre-skill-authoring`](skills/maplibre-skill-authoring/SKILL.md)   | At the end of a MapLibre task that took real research, or when asked to capture one as a skill                                                                       |
+| [`maplibre-terrain-patterns`](skills/maplibre-terrain-patterns/SKILL.md) | Adding elevation context, hillshade, or 3D terrain; choosing raster-dem sources and encodings; self-hosting DEM tiles                                                |
+| [`maplibre-tile-sources`](skills/maplibre-tile-sources/SKILL.md)         | Choosing how to supply map data; deciding between GeoJSON and tiles; configuring a basemap; debugging blank maps or missing labels                                   |
+| [`maplibre-v6-migration`](skills/maplibre-v6-migration/SKILL.md)         | A v5 app breaks after upgrading to v6, or before pinning a v6 install                                                                                                |
 
 <!-- skills-table:end -->
 
@@ -74,6 +76,16 @@ Source: https://github.com/maplibre/maplibre-agent-skills
 If you encounter something you do not know how to do, consult the MapLibre docs and this collection of skills. If neither contains the information you are looking for, or MapLibre behaves differently than a skill says report it:
 https://github.com/maplibre/maplibre-agent-skills/issues/new?template=ai-failure-report.md
 ```
+
+## Versioning
+
+This project follows [semver](https://semver.org/). Version numbers signal what changed between releases:
+
+- **Patch** (0.1.0 → 0.1.1) — content fixes, corrected examples, tooling changes. Safe to update without review.
+- **Minor** (0.1.0 → 0.2.0) — a new skill was added, a skill was removed, or how skills are consumed changed. Review the [CHANGELOG](CHANGELOG.md) to see what's new.
+- **Major** (0.x → 1.0) — a change that would break installed skills (renamed directories, restructured front matter, etc.).
+
+Each skill's front matter carries a `status` field — see [What Status Means](#what-status-means). The [CHANGELOG](CHANGELOG.md) records notable changes; entries are written by contributors via a structured PR field and accrued automatically on merge. See [CONTRIBUTING.md](CONTRIBUTING.md#how-to-fill-in-the-changelog-field) for how that works.
 
 ## Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maplibre/agent-skills",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maplibre/agent-skills",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "lint:model-pins": "node scripts/model-pin-check.js",
     "eval": "promptfoo eval",
     "eval:graded": "promptfoo eval --grader google:gemini-2.5-flash-lite --delay 8000 --no-cache -j 1",
+    "test": "node --test scripts/",
+    "check:changelog-field": "node scripts/check-changelog-field.js",
+    "generate:skills-table": "node scripts/generate-skills-table.js",
     "check": "npm run format:check && npm run spellcheck && npm run lint:markdown && npm run lint:terminology && npm run lint:model-pins && npm run validate:skills",
     "setup": "node scripts/setup-hooks.js",
     "postinstall": "node scripts/setup-hooks.js"

--- a/scripts/accrue-changelog.js
+++ b/scripts/accrue-changelog.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  parseChangelogField,
+  BUMP_ORDER,
+  VALID_CATEGORIES
+} from './lib/changelog-field.js';
+
+export function accrueEntry(
+  changelog,
+  { category, entry, bump, prNumber, prUrl }
+) {
+  const entryLine = `- ${entry} ([#${prNumber}](${prUrl}))`;
+
+  if (changelog.includes(`[#${prNumber}](${prUrl})`)) {
+    return { changelog, changed: false };
+  }
+
+  const headingMatch = changelog.match(/^## \[Unreleased\].*$/m);
+  if (!headingMatch) {
+    throw new Error('No "## [Unreleased]" heading found in CHANGELOG.md');
+  }
+
+  const headingEnd = headingMatch.index + headingMatch[0].length;
+  const preamble = changelog.substring(0, headingMatch.index);
+  const afterHeading = changelog.substring(headingEnd);
+
+  const nextVersionMatch = afterHeading.match(/\n(?=## \[)/);
+  let sectionContent, rest;
+  if (nextVersionMatch) {
+    sectionContent = afterHeading.substring(0, nextVersionMatch.index + 1);
+    rest = afterHeading.substring(nextVersionMatch.index + 1);
+  } else {
+    sectionContent = afterHeading;
+    rest = '';
+  }
+
+  const markerRegex = /\n<!-- bump:\s*(\w+)\s*-->/;
+  const existingMarker = sectionContent.match(markerRegex);
+  let effectiveBump = bump;
+  if (existingMarker) {
+    if ((BUMP_ORDER[existingMarker[1]] || 0) >= (BUMP_ORDER[bump] || 0)) {
+      effectiveBump = existingMarker[1];
+    }
+    sectionContent = sectionContent.replace(markerRegex, '');
+  }
+
+  const catRegex = new RegExp(`^### ${category}$`, 'm');
+
+  if (catRegex.test(sectionContent)) {
+    sectionContent = sectionContent.replace(
+      new RegExp(`(### ${category}\\n)(\\n)`),
+      `$1$2${entryLine}\n`
+    );
+  } else {
+    let inserted = false;
+    const catIdx = VALID_CATEGORIES.indexOf(category);
+    for (let i = catIdx + 1; i < VALID_CATEGORIES.length; i++) {
+      const nextCatRegex = new RegExp(`^### ${VALID_CATEGORIES[i]}$`, 'm');
+      const match = sectionContent.match(nextCatRegex);
+      if (match) {
+        sectionContent =
+          sectionContent.substring(0, match.index) +
+          `### ${category}\n\n${entryLine}\n\n` +
+          sectionContent.substring(match.index);
+        inserted = true;
+        break;
+      }
+    }
+    if (!inserted) {
+      sectionContent =
+        sectionContent.trimEnd() + '\n\n' + `### ${category}\n\n${entryLine}\n`;
+    }
+  }
+
+  const result = `${preamble}## [Unreleased]\n<!-- bump: ${effectiveBump} -->${sectionContent}${rest}`;
+  return { changelog: result, changed: true, effectiveBump };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const prNumber = process.env.PR_NUMBER;
+  const prUrl = process.env.PR_URL;
+  let prBody;
+  if (process.env.PR_BODY) {
+    prBody = process.env.PR_BODY;
+  } else if (process.env.PR_BODY_FILE) {
+    prBody = readFileSync(process.env.PR_BODY_FILE, 'utf8');
+  } else {
+    console.error('Set PR_BODY or PR_BODY_FILE');
+    process.exit(1);
+  }
+
+  if (!prNumber || !prUrl) {
+    console.error('Required env vars: PR_NUMBER, PR_URL');
+    process.exit(1);
+  }
+
+  const parsed = parseChangelogField(prBody);
+
+  if (parsed.errors.length > 0) {
+    console.error(
+      'Changelog field is missing or invalid in the merged PR body:\n'
+    );
+    for (const err of parsed.errors) {
+      console.error(`  - ${err}`);
+    }
+    process.exit(1);
+  }
+
+  if (parsed.bump === 'none') {
+    console.log('Bump is none — no CHANGELOG entry needed.');
+    process.exit(0);
+  }
+
+  const changelogPath = 'CHANGELOG.md';
+  const changelog = readFileSync(changelogPath, 'utf8');
+
+  const result = accrueEntry(changelog, {
+    category: parsed.category,
+    entry: parsed.entry,
+    bump: parsed.bump,
+    prNumber,
+    prUrl
+  });
+
+  if (!result.changed) {
+    console.log(`PR #${prNumber} already recorded in CHANGELOG.md — skipping.`);
+    process.exit(0);
+  }
+
+  writeFileSync(changelogPath, result.changelog);
+  console.log(
+    `Recorded #${prNumber} under ${parsed.category} (bump: ${result.effectiveBump})`
+  );
+}

--- a/scripts/accrue-changelog.js
+++ b/scripts/accrue-changelog.js
@@ -50,8 +50,8 @@ export function accrueEntry(
 
   if (catRegex.test(sectionContent)) {
     sectionContent = sectionContent.replace(
-      new RegExp(`(### ${category}\\n)(\\n)`),
-      `$1$2${entryLine}\n`
+      new RegExp(`(### ${category}\\n)\\n*`),
+      `$1\n${entryLine}\n`
     );
   } else {
     let inserted = false;

--- a/scripts/accrue-changelog.js
+++ b/scripts/accrue-changelog.js
@@ -99,13 +99,13 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const parsed = parseChangelogField(prBody);
 
   if (parsed.errors.length > 0) {
-    console.error(
-      'Changelog field is missing or invalid in the merged PR body:\n'
+    // The PR-time check is the gate; at merge time a missing or invalid field
+    // (a PR opened before the template carried it, or edited after the check ran)
+    // is surfaced as a warning and the entry is left for a human to add.
+    console.log(
+      `::warning::PR #${prNumber} has no usable Changelog field, so nothing was recorded under [Unreleased]: ${parsed.errors.join('; ')}`
     );
-    for (const err of parsed.errors) {
-      console.error(`  - ${err}`);
-    }
-    process.exit(1);
+    process.exit(0);
   }
 
   if (parsed.bump === 'none') {

--- a/scripts/accrue-changelog.test.js
+++ b/scripts/accrue-changelog.test.js
@@ -1,0 +1,119 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { accrueEntry } from './accrue-changelog.js';
+
+const BASE = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- existing skill
+
+### Changed
+
+- existing change
+`;
+
+const OPTS = {
+  category: 'Fixed',
+  entry: '`some-skill`: corrected example',
+  bump: 'patch',
+  prNumber: '42',
+  prUrl: 'https://github.com/maplibre/maplibre-agent-skills/pull/42'
+};
+
+describe('accrueEntry', () => {
+  it('creates a new category heading in canonical order', () => {
+    const result = accrueEntry(BASE, OPTS);
+    assert.ok(result.changed);
+    assert.ok(result.changelog.includes('### Fixed'));
+    assert.ok(
+      result.changelog.includes('`some-skill`: corrected example ([#42]')
+    );
+    const fixedIdx = result.changelog.indexOf('### Fixed');
+    const changedIdx = result.changelog.indexOf('### Changed');
+    const addedIdx = result.changelog.indexOf('### Added');
+    assert.ok(addedIdx < changedIdx);
+    assert.ok(changedIdx < fixedIdx);
+  });
+
+  it('inserts under an existing category heading', () => {
+    const result = accrueEntry(BASE, {
+      ...OPTS,
+      category: 'Added',
+      entry: 'new skill'
+    });
+    assert.ok(result.changed);
+    const lines = result.changelog.split('\n');
+    const addedIdx = lines.findIndex((l) => l === '### Added');
+    assert.ok(addedIdx >= 0);
+    assert.equal(
+      lines[addedIdx + 2],
+      '- new skill ([#42](' + OPTS.prUrl + '))'
+    );
+    assert.equal(lines[addedIdx + 3], '- existing skill');
+  });
+
+  it('is idempotent — same PR number skips', () => {
+    const first = accrueEntry(BASE, OPTS);
+    const second = accrueEntry(first.changelog, OPTS);
+    assert.ok(!second.changed);
+    assert.equal(first.changelog, second.changelog);
+  });
+
+  it('sets the bump marker', () => {
+    const result = accrueEntry(BASE, OPTS);
+    assert.ok(result.changelog.includes('<!-- bump: patch -->'));
+    assert.equal(result.effectiveBump, 'patch');
+  });
+
+  it('keeps the higher bump marker', () => {
+    const withMarker = BASE.replace(
+      '## [Unreleased]\n',
+      '## [Unreleased]\n<!-- bump: minor -->\n'
+    );
+    const result = accrueEntry(withMarker, { ...OPTS, bump: 'patch' });
+    assert.ok(result.changelog.includes('<!-- bump: minor -->'));
+    assert.equal(result.effectiveBump, 'minor');
+  });
+
+  it('upgrades the bump marker when new bump is higher', () => {
+    const withMarker = BASE.replace(
+      '## [Unreleased]\n',
+      '## [Unreleased]\n<!-- bump: patch -->\n'
+    );
+    const result = accrueEntry(withMarker, { ...OPTS, bump: 'major' });
+    assert.ok(result.changelog.includes('<!-- bump: major -->'));
+    assert.equal(result.effectiveBump, 'major');
+  });
+
+  it('appends category at end when no later category exists', () => {
+    const short = `# Changelog\n\n## [Unreleased]\n\n### Added\n\n- existing\n`;
+    const result = accrueEntry(short, {
+      ...OPTS,
+      category: 'Internal',
+      entry: 'CI change'
+    });
+    assert.ok(result.changelog.includes('### Internal'));
+    const internalIdx = result.changelog.indexOf('### Internal');
+    const addedIdx = result.changelog.indexOf('### Added');
+    assert.ok(internalIdx > addedIdx);
+  });
+
+  it('handles empty unreleased section', () => {
+    const empty = `# Changelog\n\n## [Unreleased]\n`;
+    const result = accrueEntry(empty, OPTS);
+    assert.ok(result.changed);
+    assert.ok(result.changelog.includes('### Fixed'));
+    assert.ok(result.changelog.includes(OPTS.entry));
+  });
+
+  it('preserves content after unreleased section', () => {
+    const withPrev =
+      BASE + '\n## [0.1.0] - 2026-01-01\n\n### Added\n\n- initial\n';
+    const result = accrueEntry(withPrev, OPTS);
+    assert.ok(result.changelog.includes('## [0.1.0] - 2026-01-01'));
+    assert.ok(result.changelog.includes('- initial'));
+  });
+});

--- a/scripts/accrue-changelog.test.js
+++ b/scripts/accrue-changelog.test.js
@@ -101,6 +101,44 @@ describe('accrueEntry', () => {
     assert.ok(internalIdx > addedIdx);
   });
 
+  it('inserts under a category heading that has no blank line after it', () => {
+    const noBlank = `# Changelog\n\n## [Unreleased]\n\n### Added\n- existing skill\n`;
+    const result = accrueEntry(noBlank, {
+      ...OPTS,
+      category: 'Added',
+      entry: 'new skill'
+    });
+    assert.ok(result.changed);
+    const lines = result.changelog.split('\n');
+    const addedIdx = lines.findIndex((l) => l === '### Added');
+    assert.ok(addedIdx >= 0);
+    assert.equal(lines[addedIdx + 1], '');
+    assert.equal(
+      lines[addedIdx + 2],
+      '- new skill ([#42](' + OPTS.prUrl + '))'
+    );
+    assert.equal(lines[addedIdx + 3], '- existing skill');
+  });
+
+  it('inserts under a category heading with multiple trailing blank lines', () => {
+    const extraBlanks = `# Changelog\n\n## [Unreleased]\n\n### Added\n\n\n\n- existing skill\n`;
+    const result = accrueEntry(extraBlanks, {
+      ...OPTS,
+      category: 'Added',
+      entry: 'new skill'
+    });
+    assert.ok(result.changed);
+    const lines = result.changelog.split('\n');
+    const addedIdx = lines.findIndex((l) => l === '### Added');
+    assert.ok(addedIdx >= 0);
+    assert.equal(lines[addedIdx + 1], '');
+    assert.equal(
+      lines[addedIdx + 2],
+      '- new skill ([#42](' + OPTS.prUrl + '))'
+    );
+    assert.equal(lines[addedIdx + 3], '- existing skill');
+  });
+
   it('handles empty unreleased section', () => {
     const empty = `# Changelog\n\n## [Unreleased]\n`;
     const result = accrueEntry(empty, OPTS);

--- a/scripts/changelog-field.test.js
+++ b/scripts/changelog-field.test.js
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseChangelogField } from './lib/changelog-field.js';
+
+describe('parseChangelogField', () => {
+  it('parses valid fields', () => {
+    const body =
+      '## Changelog\n\nBump: minor\nCategory: Added\nEntry: `new-skill`: added skill';
+    const result = parseChangelogField(body);
+    assert.deepStrictEqual(result, {
+      bump: 'minor',
+      category: 'Added',
+      entry: '`new-skill`: added skill',
+      errors: []
+    });
+  });
+
+  it('handles bold keys', () => {
+    const body =
+      '**Bump:** patch\n**Category:** Fixed\n**Entry:** corrected example';
+    const result = parseChangelogField(body);
+    assert.deepStrictEqual(result, {
+      bump: 'patch',
+      category: 'Fixed',
+      entry: 'corrected example',
+      errors: []
+    });
+  });
+
+  it('strips HTML comments before parsing', () => {
+    const body =
+      '<!-- instructions here -->\nBump: minor\nCategory: Changed\nEntry: updated content';
+    const result = parseChangelogField(body);
+    assert.equal(result.bump, 'minor');
+    assert.equal(result.errors.length, 0);
+  });
+
+  it('returns none with no entry or category required', () => {
+    const body = 'Bump: none\nSome other text';
+    const result = parseChangelogField(body);
+    assert.deepStrictEqual(result, {
+      bump: 'none',
+      category: null,
+      entry: null,
+      errors: []
+    });
+  });
+
+  it('errors on missing Entry when bump is not none', () => {
+    const body = 'Bump: patch\nCategory: Changed';
+    const result = parseChangelogField(body);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors.some((e) => e.includes('Entry')));
+  });
+
+  it('errors on missing Category when bump is not none', () => {
+    const body = 'Bump: minor\nEntry: something';
+    const result = parseChangelogField(body);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors.some((e) => e.includes('Category')));
+  });
+
+  it('errors on invalid bump level', () => {
+    const body = 'Bump: huge';
+    const result = parseChangelogField(body);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors[0].includes('huge'));
+  });
+
+  it('errors on invalid category', () => {
+    const body = 'Bump: patch\nCategory: Deprecated\nEntry: something';
+    const result = parseChangelogField(body);
+    assert.ok(result.errors.length > 0);
+    assert.ok(result.errors[0].includes('Deprecated'));
+  });
+
+  it('errors on empty body', () => {
+    const result = parseChangelogField('');
+    assert.ok(result.errors.length > 0);
+  });
+
+  it('errors on null body', () => {
+    const result = parseChangelogField(null);
+    assert.ok(result.errors.length > 0);
+  });
+
+  it('accepts case-insensitive keys and categories', () => {
+    const body = 'bump: MINOR\ncategory: internal\nentry: CI change';
+    const result = parseChangelogField(body);
+    assert.equal(result.bump, 'minor');
+    assert.equal(result.category, 'Internal');
+    assert.equal(result.errors.length, 0);
+  });
+
+  it('uses first match for each key', () => {
+    const body =
+      'Bump: patch\nBump: major\nCategory: Added\nEntry: first entry\nEntry: second';
+    const result = parseChangelogField(body);
+    assert.equal(result.bump, 'patch');
+    assert.equal(result.entry, 'first entry');
+  });
+});

--- a/scripts/changelog-section.js
+++ b/scripts/changelog-section.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export function extractSection(changelog, version) {
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const headingRegex = new RegExp(`^## \\[${escapedVersion}\\]`, 'm');
+  const match = changelog.match(headingRegex);
+  if (!match) return null;
+
+  const lineEnd = changelog.indexOf('\n', match.index);
+  if (lineEnd === -1) return '';
+
+  const afterHeading = changelog.substring(lineEnd + 1);
+  const nextHeading = afterHeading.match(/^## \[/m);
+  const content = nextHeading
+    ? afterHeading.substring(0, nextHeading.index)
+    : afterHeading;
+
+  return content.trim();
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const version = process.argv[2];
+  if (!version) {
+    console.error('Usage: changelog-section.js <version>');
+    process.exit(1);
+  }
+
+  const changelog = readFileSync('CHANGELOG.md', 'utf8');
+  const section = extractSection(changelog, version);
+
+  if (section === null) {
+    console.error(`No section found for version ${version}`);
+    process.exit(1);
+  }
+
+  process.stdout.write(section + '\n');
+}

--- a/scripts/check-changelog-field.js
+++ b/scripts/check-changelog-field.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { parseChangelogField } from './lib/changelog-field.js';
+
+const body = process.env.PR_BODY;
+const result = parseChangelogField(body);
+
+if (result.errors.length > 0) {
+  console.error('Changelog field validation failed:\n');
+  for (const err of result.errors) {
+    console.error(`  - ${err}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Changelog field valid: bump=${result.bump}` +
+    (result.category ? `, category=${result.category}` : '')
+);

--- a/scripts/cut-release.js
+++ b/scripts/cut-release.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { setOutputs } from './lib/github-output.js';
+
+export function bumpVersion(version, level) {
+  const [major, minor, patch] = version.split('.').map(Number);
+  switch (level) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      throw new Error(`Invalid level: ${level}`);
+  }
+}
+
+export function cutRelease({
+  changelog,
+  packageJson,
+  packageLockJson,
+  level,
+  date
+}) {
+  const pkg = JSON.parse(packageJson);
+  const currentVersion = pkg.version;
+
+  const headingMatch = changelog.match(/^## \[Unreleased\].*$/m);
+  if (!headingMatch) {
+    throw new Error('No "## [Unreleased]" heading found');
+  }
+
+  const headingEnd = headingMatch.index + headingMatch[0].length;
+  const preamble = changelog.substring(0, headingMatch.index);
+  const afterHeading = changelog.substring(headingEnd);
+
+  const nextVersionMatch = afterHeading.match(/\n(?=## \[)/);
+  let sectionContent, rest;
+  if (nextVersionMatch) {
+    sectionContent = afterHeading.substring(0, nextVersionMatch.index + 1);
+    rest = afterHeading.substring(nextVersionMatch.index + 1);
+  } else {
+    sectionContent = afterHeading;
+    rest = '';
+  }
+
+  const markerRegex = /\n<!-- bump:\s*(\w+)\s*-->/;
+  const marker = sectionContent.match(markerRegex);
+  let effectiveLevel;
+
+  if (level === 'auto') {
+    if (marker) {
+      effectiveLevel = marker[1];
+    } else {
+      const trimmed = sectionContent.replace(markerRegex, '').trim();
+      if (!trimmed) {
+        throw new Error(
+          'No pending bump marker and no entries under [Unreleased]. Nothing to release.'
+        );
+      }
+      throw new Error(
+        'Entries found under [Unreleased] but no bump marker. Specify the level explicitly (patch, minor, or major).'
+      );
+    }
+  } else {
+    effectiveLevel = level;
+  }
+
+  sectionContent = sectionContent.replace(markerRegex, '');
+  const newVersion = bumpVersion(currentVersion, effectiveLevel);
+  const versionHeading = `## [${newVersion}] - ${date}`;
+
+  const hasLinks =
+    /^\[Unreleased\]:\s/m.test(changelog) ||
+    /^\[\d+\.\d+\.\d+\]:\s/m.test(changelog);
+
+  let newChangelog;
+  if (hasLinks) {
+    const repoUrl = 'https://github.com/maplibre/maplibre-agent-skills';
+    const linkSection = changelog.match(/(\n\[Unreleased\]:[\s\S]*$)/m);
+    const beforeLinks = linkSection
+      ? changelog.substring(0, linkSection.index)
+      : changelog;
+    const unreleasedLink = `[Unreleased]: ${repoUrl}/compare/v${newVersion}...HEAD`;
+    const versionLink = currentVersion
+      ? `[${newVersion}]: ${repoUrl}/compare/v${currentVersion}...v${newVersion}`
+      : `[${newVersion}]: ${repoUrl}/releases/tag/v${newVersion}`;
+    const existingLinks = linkSection
+      ? linkSection[0].replace(/^\n\[Unreleased\]:.*$/m, '').trim()
+      : '';
+    const links = [unreleasedLink, versionLink, existingLinks]
+      .filter(Boolean)
+      .join('\n');
+    newChangelog = `${preamble}## [Unreleased]\n\n${versionHeading}${sectionContent}${rest}\n${links}\n`;
+  } else {
+    newChangelog = `${preamble}## [Unreleased]\n\n${versionHeading}${sectionContent}${rest}`;
+  }
+
+  pkg.version = newVersion;
+  const newPackageJson = JSON.stringify(pkg, null, 2) + '\n';
+
+  let newPackageLockJson = packageLockJson;
+  if (packageLockJson) {
+    let count = 0;
+    newPackageLockJson = packageLockJson.replace(
+      /"version":\s*"[^"]*"/g,
+      (match) => {
+        count++;
+        return count <= 2 ? `"version": "${newVersion}"` : match;
+      }
+    );
+  }
+
+  return {
+    changelog: newChangelog,
+    packageJson: newPackageJson,
+    packageLockJson: newPackageLockJson,
+    version: newVersion
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  const levelIdx = args.indexOf('--level');
+  if (levelIdx === -1 || !args[levelIdx + 1]) {
+    process.stderr.write(
+      'Usage: cut-release.js --level <auto|patch|minor|major>\n'
+    );
+    process.exit(1);
+  }
+  const level = args[levelIdx + 1];
+  const date =
+    process.env.RELEASE_DATE || new Date().toISOString().slice(0, 10);
+
+  const changelog = readFileSync('CHANGELOG.md', 'utf8');
+  const packageJson = readFileSync('package.json', 'utf8');
+  let packageLockJson;
+  try {
+    packageLockJson = readFileSync('package-lock.json', 'utf8');
+  } catch {
+    // no lockfile
+  }
+
+  let result;
+  try {
+    result = cutRelease({
+      changelog,
+      packageJson,
+      packageLockJson,
+      level,
+      date
+    });
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
+  writeFileSync('CHANGELOG.md', result.changelog);
+  writeFileSync('package.json', result.packageJson);
+  if (result.packageLockJson) {
+    writeFileSync('package-lock.json', result.packageLockJson);
+  }
+
+  process.stderr.write(
+    `Updated CHANGELOG.md and package.json: ${result.version}\n`
+  );
+
+  const { updateReadme } = await import('./generate-skills-table.js');
+  updateReadme();
+
+  execSync('npx prettier --write CHANGELOG.md README.md package.json', {
+    stdio: ['ignore', 'ignore', 'inherit']
+  });
+
+  setOutputs({ version: result.version });
+}

--- a/scripts/cut-release.test.js
+++ b/scripts/cut-release.test.js
@@ -1,0 +1,162 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { bumpVersion, cutRelease } from './cut-release.js';
+
+describe('bumpVersion', () => {
+  it('bumps minor', () => {
+    assert.equal(bumpVersion('0.1.0', 'minor'), '0.2.0');
+  });
+
+  it('bumps patch', () => {
+    assert.equal(bumpVersion('0.1.0', 'patch'), '0.1.1');
+  });
+
+  it('bumps major', () => {
+    assert.equal(bumpVersion('0.1.0', 'major'), '1.0.0');
+  });
+
+  it('bumps from higher versions', () => {
+    assert.equal(bumpVersion('2.3.4', 'minor'), '2.4.0');
+    assert.equal(bumpVersion('2.3.4', 'patch'), '2.3.5');
+  });
+});
+
+describe('cutRelease', () => {
+  const changelog = `# Changelog
+
+Preamble.
+
+## [Unreleased]
+<!-- bump: minor -->
+
+### Added
+
+- New skill
+
+### Internal
+
+- CI improvement
+`;
+
+  const packageJson =
+    JSON.stringify({ name: 'test', version: '0.1.0' }, null, 2) + '\n';
+
+  it('rewrites changelog with version heading and date', () => {
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    assert.equal(result.version, '0.2.0');
+    assert.ok(result.changelog.includes('## [0.2.0] - 2026-08-25'));
+    assert.ok(result.changelog.includes('## [Unreleased]'));
+    assert.ok(!result.changelog.includes('<!-- bump:'));
+  });
+
+  it('inserts empty unreleased above the new version', () => {
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    const unreleasedIdx = result.changelog.indexOf('## [Unreleased]');
+    const versionIdx = result.changelog.indexOf('## [0.2.0]');
+    assert.ok(unreleasedIdx < versionIdx);
+  });
+
+  it('uses auto level from marker', () => {
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    assert.equal(result.version, '0.2.0');
+  });
+
+  it('uses explicit level override', () => {
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      level: 'major',
+      date: '2026-08-25'
+    });
+    assert.equal(result.version, '1.0.0');
+    assert.ok(result.changelog.includes('## [1.0.0] - 2026-08-25'));
+  });
+
+  it('updates package.json version', () => {
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    const pkg = JSON.parse(result.packageJson);
+    assert.equal(pkg.version, '0.2.0');
+  });
+
+  it('updates package-lock.json version', () => {
+    const lockJson =
+      '{\n  "name": "test",\n  "version": "0.1.0",\n  "packages": {\n    "": {\n      "version": "0.1.0"\n    }\n  }\n}\n';
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      packageLockJson: lockJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    assert.ok(result.packageLockJson.includes('"version": "0.2.0"'));
+    assert.ok(!result.packageLockJson.includes('"version": "0.1.0"'));
+  });
+
+  it('errors on auto with no marker and no entries', () => {
+    const empty = '# Changelog\n\n## [Unreleased]\n';
+    assert.throws(() => {
+      cutRelease({
+        changelog: empty,
+        packageJson,
+        level: 'auto',
+        date: '2026-08-25'
+      });
+    }, /Nothing to release/);
+  });
+
+  it('errors on auto with entries but no marker', () => {
+    const noMarker = '# Changelog\n\n## [Unreleased]\n\n### Added\n\n- stuff\n';
+    assert.throws(() => {
+      cutRelease({
+        changelog: noMarker,
+        packageJson,
+        level: 'auto',
+        date: '2026-08-25'
+      });
+    }, /Specify the level explicitly/);
+  });
+
+  it('preserves existing version sections', () => {
+    const withPrev =
+      changelog + '\n## [0.1.0] - 2026-01-01\n\n### Added\n\n- initial\n';
+    const result = cutRelease({
+      changelog: withPrev,
+      packageJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    assert.ok(result.changelog.includes('## [0.1.0] - 2026-01-01'));
+    assert.ok(result.changelog.includes('- initial'));
+  });
+
+  it('preserves package.json formatting', () => {
+    const result = cutRelease({
+      changelog,
+      packageJson,
+      level: 'auto',
+      date: '2026-08-25'
+    });
+    assert.ok(result.packageJson.endsWith('\n'));
+    assert.ok(result.packageJson.includes('  "version"'));
+  });
+});

--- a/scripts/generate-skills-table.js
+++ b/scripts/generate-skills-table.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const START_MARKER = '<!-- skills-table:start -->';
+const END_MARKER = '<!-- skills-table:end -->';
+const GENERATED_COMMENT =
+  '<!-- Rows are regenerated at release by `npm run generate:skills-table`: sorted by name, new skills added, removed skills dropped. Edit the "Use when" text in place; it is preserved. -->';
+
+export function extractUseWhen(description) {
+  const idx = description.toLowerCase().lastIndexOf('use when');
+  if (idx === -1) return { text: description, fallback: true };
+  let text = description.substring(idx + 8).trim();
+  if (text.endsWith('.')) text = text.slice(0, -1);
+  text = text.charAt(0).toUpperCase() + text.slice(1);
+  return { text, fallback: false };
+}
+
+// Parses `| [`name`](skills/name/SKILL.md) | cell |` rows into a name → cell map.
+export function parseExistingRows(block) {
+  const rows = new Map();
+  const re = /^\|\s*\[`([^`]+)`\]\([^)]*\)\s*\|\s*(.*?)\s*\|\s*$/gm;
+  for (const m of block.matchAll(re)) rows.set(m[1], m[2]);
+  return rows;
+}
+
+export function generateTable(skills, existing = new Map()) {
+  const warnings = [];
+  const rows = skills
+    .filter((s) => s.status !== 'process')
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((s) => {
+      let text = existing.get(s.name);
+      if (text === undefined) {
+        const uw = extractUseWhen(s.description);
+        text = uw.text;
+        if (uw.fallback) {
+          warnings.push(
+            `${s.name}: new row with no "Use when" clause in its description, using the full description — edit the cell in README.md`
+          );
+        }
+      }
+      return `| [\`${s.name}\`](skills/${s.name}/SKILL.md) | ${text} |`;
+    });
+
+  const header = '| Skill | Use when |\n| --- | --- |';
+  return { table: header + '\n' + rows.join('\n'), warnings };
+}
+
+export function readSkills(skillsDir = 'skills') {
+  const entries = readdirSync(skillsDir, { withFileTypes: true });
+  const skills = [];
+
+  for (const dir of entries.filter((e) => e.isDirectory())) {
+    const skillFile = join(skillsDir, dir.name, 'SKILL.md');
+    let content;
+    try {
+      content = readFileSync(skillFile, 'utf8');
+    } catch {
+      continue;
+    }
+
+    if (!content.startsWith('---\n')) continue;
+    const fmEnd = content.indexOf('\n---\n', 4);
+    if (fmEnd === -1) continue;
+
+    const fm = content.substring(4, fmEnd);
+    const name = fm.match(/^name:\s*(.+)$/m)?.[1]?.trim();
+    const description = fm.match(/^description:\s*(.+)$/m)?.[1]?.trim();
+    const status = fm.match(/^status:\s*(\S+)$/m)?.[1]?.trim();
+
+    if (name && description) {
+      skills.push({ name, description, status: status || '' });
+    }
+  }
+
+  return skills;
+}
+
+function readBlock(readme) {
+  const startIdx = readme.indexOf(START_MARKER);
+  const endIdx = readme.indexOf(END_MARKER);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    throw new Error(
+      `README.md is missing ${START_MARKER} or ${END_MARKER} markers`
+    );
+  }
+  return {
+    before: readme.substring(0, startIdx),
+    block: readme.substring(startIdx + START_MARKER.length, endIdx),
+    after: readme.substring(endIdx + END_MARKER.length)
+  };
+}
+
+// Returns true when the README's rows already match what generation would produce.
+export function tableIsCurrent(readme, skills) {
+  const { block } = readBlock(readme);
+  const existing = parseExistingRows(block);
+  const { table } = generateTable(skills, existing);
+  const expected = parseExistingRows(table);
+  const actual = [...existing.entries()];
+  const wanted = [...expected.entries()];
+  return JSON.stringify(actual) === JSON.stringify(wanted);
+}
+
+export function updateReadme(readmePath = 'README.md', skillsDir = 'skills') {
+  const skills = readSkills(skillsDir);
+  const readme = readFileSync(readmePath, 'utf8');
+  const { before, block, after } = readBlock(readme);
+  const existing = parseExistingRows(block);
+  const { table, warnings } = generateTable(skills, existing);
+
+  for (const w of warnings) console.warn(`Warning: ${w}`);
+
+  const newReadme = `${before}${START_MARKER}\n${GENERATED_COMMENT}\n\n${table}\n\n${END_MARKER}${after}`;
+  writeFileSync(readmePath, newReadme);
+  console.log(`Updated README.md skills table (${skills.length} skills)`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  if (process.argv.includes('--check')) {
+    const readme = readFileSync('README.md', 'utf8');
+    if (!tableIsCurrent(readme, readSkills())) {
+      console.error(
+        'README skills table is stale. Run `npm run generate:skills-table` to update.'
+      );
+      process.exit(1);
+    }
+    console.log('README skills table is up to date.');
+  } else {
+    updateReadme();
+  }
+}

--- a/scripts/generate-skills-table.js
+++ b/scripts/generate-skills-table.js
@@ -28,7 +28,6 @@ export function parseExistingRows(block) {
 export function generateTable(skills, existing = new Map()) {
   const warnings = [];
   const rows = skills
-    .filter((s) => s.status !== 'process')
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((s) => {
       let text = existing.get(s.name);

--- a/scripts/generate-skills-table.test.js
+++ b/scripts/generate-skills-table.test.js
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractUseWhen,
+  generateTable,
+  parseExistingRows,
+  tableIsCurrent
+} from './generate-skills-table.js';
+
+describe('extractUseWhen', () => {
+  it('extracts text after last "Use when"', () => {
+    const desc = 'Some description. Use when building a map with custom tiles.';
+    const result = extractUseWhen(desc);
+    assert.equal(result.text, 'Building a map with custom tiles');
+    assert.equal(result.fallback, false);
+  });
+
+  it('strips trailing period', () => {
+    const desc = 'Desc. Use when doing something.';
+    assert.equal(extractUseWhen(desc).text, 'Doing something');
+  });
+
+  it('capitalizes the first letter', () => {
+    assert.ok(
+      extractUseWhen('Desc. Use when styling a map.').text.startsWith('S')
+    );
+  });
+
+  it('falls back to full description when no "Use when" exists', () => {
+    const desc = 'How to configure data sources for MapLibre';
+    const result = extractUseWhen(desc);
+    assert.equal(result.text, desc);
+    assert.equal(result.fallback, true);
+  });
+
+  it('uses the LAST occurrence of "Use when"', () => {
+    const desc = 'Use when first case. More text. Use when second case.';
+    assert.equal(extractUseWhen(desc).text, 'Second case');
+  });
+});
+
+const skills = [
+  {
+    name: 'beta-skill',
+    description: 'Beta. Use when doing B.',
+    status: 'verified'
+  },
+  {
+    name: 'alpha-skill',
+    description: 'Alpha. Use when doing A.',
+    status: 'verified'
+  },
+  {
+    name: 'process-skill',
+    description: 'Process. Use when maintaining.',
+    status: 'process'
+  },
+  {
+    name: 'no-usewhen',
+    description: 'Full description only',
+    status: 'provisional'
+  }
+];
+
+describe('parseExistingRows', () => {
+  it('reads name and cell from prettier-padded rows', () => {
+    const block = [
+      '| Skill                                  | Use when         |',
+      '| -------------------------------------- | ---------------- |',
+      '| [`alpha-skill`](skills/alpha-skill/SKILL.md) | Hand-written A   |',
+      '| [`beta-skill`](skills/beta-skill/SKILL.md)   | Hand-written B |'
+    ].join('\n');
+    const rows = parseExistingRows(block);
+    assert.deepEqual(
+      [...rows.entries()],
+      [
+        ['alpha-skill', 'Hand-written A'],
+        ['beta-skill', 'Hand-written B']
+      ]
+    );
+  });
+});
+
+describe('generateTable', () => {
+  it('sorts rows by skill name', () => {
+    const { table } = generateTable(skills);
+    assert.ok(table.indexOf('alpha-skill') < table.indexOf('beta-skill'));
+  });
+
+  it('skips process skills', () => {
+    assert.ok(!generateTable(skills).table.includes('process-skill'));
+  });
+
+  it('warns on fallback descriptions', () => {
+    assert.ok(
+      generateTable(skills).warnings.some((w) => w.includes('no-usewhen'))
+    );
+  });
+
+  it('generates valid markdown table header', () => {
+    const { table } = generateTable(skills);
+    assert.ok(table.startsWith('| Skill | Use when |'));
+    assert.ok(table.includes('| --- | --- |'));
+  });
+
+  it('links to SKILL.md', () => {
+    assert.ok(
+      generateTable(skills).table.includes(
+        '[`alpha-skill`](skills/alpha-skill/SKILL.md)'
+      )
+    );
+  });
+
+  it('preserves an existing cell over the derived text', () => {
+    const existing = new Map([['alpha-skill', 'Hand-written A']]);
+    const { table, warnings } = generateTable(skills, existing);
+    assert.ok(table.includes('| Hand-written A |'));
+    assert.ok(table.includes('| Doing B |'));
+    assert.ok(!warnings.some((w) => w.includes('alpha-skill')));
+  });
+
+  it('drops rows for skills that no longer exist', () => {
+    const existing = new Map([['gone-skill', 'Old cell']]);
+    assert.ok(!generateTable(skills, existing).table.includes('gone-skill'));
+  });
+});
+
+describe('tableIsCurrent', () => {
+  const wrap = (rows) =>
+    `# T\n\n<!-- skills-table:start -->\n<!-- c -->\n\n| Skill | Use when |\n| --- | --- |\n${rows}\n\n<!-- skills-table:end -->\n`;
+  const two = skills.filter(
+    (s) => s.name.endsWith('-skill') && s.status !== 'process'
+  );
+
+  it('is current when rows are sorted and complete, whatever the cell text', () => {
+    const readme = wrap(
+      '| [`alpha-skill`](skills/alpha-skill/SKILL.md) | X |\n| [`beta-skill`](skills/beta-skill/SKILL.md) | Y |'
+    );
+    assert.equal(tableIsCurrent(readme, two), true);
+  });
+
+  it('is stale when a skill is missing or out of order', () => {
+    const missing = wrap(
+      '| [`alpha-skill`](skills/alpha-skill/SKILL.md) | X |'
+    );
+    assert.equal(tableIsCurrent(missing, two), false);
+    const unsorted = wrap(
+      '| [`beta-skill`](skills/beta-skill/SKILL.md) | Y |\n| [`alpha-skill`](skills/alpha-skill/SKILL.md) | X |'
+    );
+    assert.equal(tableIsCurrent(unsorted, two), false);
+  });
+});

--- a/scripts/generate-skills-table.test.js
+++ b/scripts/generate-skills-table.test.js
@@ -87,8 +87,8 @@ describe('generateTable', () => {
     assert.ok(table.indexOf('alpha-skill') < table.indexOf('beta-skill'));
   });
 
-  it('skips process skills', () => {
-    assert.ok(!generateTable(skills).table.includes('process-skill'));
+  it('includes process skills', () => {
+    assert.ok(generateTable(skills).table.includes('process-skill'));
   });
 
   it('warns on fallback descriptions', () => {

--- a/scripts/lib/changelog-field.js
+++ b/scripts/lib/changelog-field.js
@@ -1,0 +1,69 @@
+const VALID_BUMPS = new Set(['none', 'patch', 'minor', 'major']);
+const VALID_CATEGORIES = ['Added', 'Changed', 'Fixed', 'Removed', 'Internal'];
+const CATEGORY_SET = new Set(VALID_CATEGORIES.map((c) => c.toLowerCase()));
+const BUMP_ORDER = { patch: 1, minor: 2, major: 3 };
+
+function parseLine(text, key) {
+  for (const line of text.split('\n')) {
+    const cleaned = line.replace(/\*\*/g, '').trim();
+    const match = cleaned.match(new RegExp(`^${key}:\\s*(.+)`, 'i'));
+    if (match) return match[1].trim();
+  }
+  return null;
+}
+
+function parseChangelogField(body) {
+  if (!body) {
+    return { errors: ['PR body is empty.'] };
+  }
+
+  const stripped = body.replace(/<!--[\s\S]*?-->/g, '');
+  const errors = [];
+
+  const bumpRaw = parseLine(stripped, 'Bump');
+  if (bumpRaw === null) {
+    errors.push(
+      'Missing Bump field. Expected: Bump: none | patch | minor | major'
+    );
+    return { errors };
+  }
+
+  const bump = bumpRaw.toLowerCase();
+  if (!VALID_BUMPS.has(bump)) {
+    errors.push(
+      `Invalid Bump "${bumpRaw}". Expected: none, patch, minor, major.`
+    );
+    return { errors };
+  }
+
+  if (bump === 'none') {
+    return { bump, category: null, entry: null, errors: [] };
+  }
+
+  const entryRaw = parseLine(stripped, 'Entry');
+  const categoryRaw = parseLine(stripped, 'Category');
+
+  if (entryRaw === null) errors.push('Bump is not none — Entry is required.');
+  if (categoryRaw === null) {
+    errors.push('Bump is not none — Category is required.');
+  } else if (!CATEGORY_SET.has(categoryRaw.toLowerCase())) {
+    errors.push(
+      `Invalid Category "${categoryRaw}". Expected: ${VALID_CATEGORIES.join(', ')}.`
+    );
+  }
+
+  if (errors.length > 0) return { errors };
+
+  const category = VALID_CATEGORIES.find(
+    (c) => c.toLowerCase() === categoryRaw.toLowerCase()
+  );
+  return { bump, category, entry: entryRaw, errors: [] };
+}
+
+export {
+  parseChangelogField,
+  VALID_BUMPS,
+  VALID_CATEGORIES,
+  BUMP_ORDER,
+  CATEGORY_SET
+};

--- a/scripts/lib/github-output.js
+++ b/scripts/lib/github-output.js
@@ -1,0 +1,10 @@
+import { appendFileSync } from 'node:fs';
+
+// Writes key=value pairs to $GITHUB_OUTPUT (or stdout when unset, for local runs).
+export function setOutputs(outputs, file = process.env.GITHUB_OUTPUT) {
+  const lines = Object.entries(outputs)
+    .map(([k, v]) => `${k}=${String(v)}\n`)
+    .join('');
+  if (file) appendFileSync(file, lines);
+  else process.stdout.write(lines);
+}

--- a/scripts/merged-pr.js
+++ b/scripts/merged-pr.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Merge-time lookup for changelog.yml: which PR produced this commit, and should it be recorded?
+import { writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { setOutputs } from './lib/github-output.js';
+
+const AUTOMATION_PREFIXES = ['chore(changelog):', 'chore(release):'];
+
+export function isAutomationCommit(subject) {
+  return AUTOMATION_PREFIXES.some((p) => subject.startsWith(p));
+}
+
+// Picks the merged PR from the commit's associated pull requests.
+export function selectPullRequest(pulls) {
+  if (!Array.isArray(pulls)) return null;
+  return pulls.find((p) => p.merged_at) ?? pulls[0] ?? null;
+}
+
+export async function fetchPullsForCommit({ repo, sha, token }) {
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/commits/${sha}/pulls`,
+    {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status} looking up PRs for ${sha}`);
+  }
+  return res.json();
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const {
+    GITHUB_REPOSITORY: repo,
+    GITHUB_SHA: sha,
+    GH_TOKEN: token,
+    PR_BODY_FILE
+  } = process.env;
+  if (!repo || !sha || !token || !PR_BODY_FILE) {
+    console.error(
+      'Required env: GITHUB_REPOSITORY, GITHUB_SHA, GH_TOKEN, PR_BODY_FILE'
+    );
+    process.exit(1);
+  }
+
+  const subject = execFileSync('git', ['log', '-1', '--format=%s'], {
+    encoding: 'utf8'
+  }).trim();
+  if (isAutomationCommit(subject)) {
+    console.log(`Automation commit ("${subject}") — skipping.`);
+    setOutputs({ found: 'false' });
+    process.exit(0);
+  }
+
+  const pr = selectPullRequest(await fetchPullsForCommit({ repo, sha, token }));
+  if (!pr) {
+    console.log('No PR found for this commit — skipping.');
+    setOutputs({ found: 'false' });
+    process.exit(0);
+  }
+
+  writeFileSync(PR_BODY_FILE, pr.body ?? '');
+  setOutputs({ found: 'true', number: pr.number, url: pr.html_url });
+  console.log(`Found #${pr.number}: ${pr.html_url}`);
+}

--- a/scripts/merged-pr.test.js
+++ b/scripts/merged-pr.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isAutomationCommit, selectPullRequest } from './merged-pr.js';
+
+describe('isAutomationCommit', () => {
+  it('skips changelog and release commits', () => {
+    assert.equal(isAutomationCommit('chore(changelog): record #12'), true);
+    assert.equal(isAutomationCommit('chore(release): v0.2.0'), true);
+  });
+  it('keeps everything else', () => {
+    assert.equal(
+      isAutomationCommit('feat(skills): add fonts skill (#12)'),
+      false
+    );
+    assert.equal(isAutomationCommit('chore(deps): bump prettier'), false);
+  });
+});
+
+describe('selectPullRequest', () => {
+  it('prefers the merged PR when a commit belongs to several', () => {
+    const pulls = [
+      { number: 1, merged_at: null },
+      { number: 2, merged_at: '2026-08-25T00:00:00Z' }
+    ];
+    assert.equal(selectPullRequest(pulls).number, 2);
+  });
+  it('falls back to the first PR, or null', () => {
+    assert.equal(selectPullRequest([{ number: 7 }]).number, 7);
+    assert.equal(selectPullRequest([]), null);
+    assert.equal(selectPullRequest(undefined), null);
+  });
+});

--- a/scripts/release-pr-body.js
+++ b/scripts/release-pr-body.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Prints the body for the release PR opened by release.yml.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { extractSection } from './changelog-section.js';
+
+export function releasePrBody(changelog, version) {
+  const section = extractSection(changelog, version);
+  if (section === null) {
+    throw new Error(`No CHANGELOG section for ${version}`);
+  }
+  return [
+    `## What this changes`,
+    ``,
+    `Release v${version}. Merging tags \`v${version}\` and publishes the GitHub Release from the section below.`,
+    ``,
+    section,
+    ``,
+    `## Changelog`,
+    ``,
+    `Bump: none`,
+    ``
+  ].join('\n');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const version = process.argv[2];
+  if (!version) {
+    console.error('Usage: release-pr-body.js <version>');
+    process.exit(1);
+  }
+  process.stdout.write(
+    releasePrBody(readFileSync('CHANGELOG.md', 'utf8'), version)
+  );
+}

--- a/scripts/release-pr-body.test.js
+++ b/scripts/release-pr-body.test.js
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { releasePrBody } from './release-pr-body.js';
+import { parseChangelogField } from './lib/changelog-field.js';
+
+const changelog = `# Changelog\n\n## [Unreleased]\n\n## [0.2.0] - 2026-09-01\n\n### Added\n\n- thing ([#9](u))\n\n## [0.1.0] - 2026-08-25\n\n### Added\n\n- old\n`;
+
+describe('releasePrBody', () => {
+  it("includes only that version's section", () => {
+    const body = releasePrBody(changelog, '0.2.0');
+    assert.ok(body.includes('- thing ([#9](u))'));
+    assert.ok(!body.includes('- old'));
+  });
+  it('carries Bump: none so merging it records nothing', () => {
+    const parsed = parseChangelogField(releasePrBody(changelog, '0.2.0'));
+    assert.equal(parsed.errors.length, 0);
+    assert.equal(parsed.bump, 'none');
+  });
+  it('throws for an unknown version', () => {
+    assert.throws(() => releasePrBody(changelog, '9.9.9'));
+  });
+});

--- a/scripts/version-changed.js
+++ b/scripts/version-changed.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Tag-time check for changelog.yml: did package.json's version change in this commit?
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { setOutputs } from './lib/github-output.js';
+
+export function readVersion(packageJsonText) {
+  try {
+    return JSON.parse(packageJsonText).version ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function versionChange(previousText, currentText) {
+  const prev = readVersion(previousText);
+  const curr = readVersion(currentText);
+  return curr && prev !== curr ? curr : null;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  let previous = '';
+  try {
+    previous = execFileSync('git', ['show', 'HEAD~1:package.json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+  } catch {
+    // first commit, or no package.json in the parent
+  }
+  const current = readFileSync('package.json', 'utf8');
+  const version = versionChange(previous, current);
+  if (version) {
+    console.log(`package.json version changed to ${version}`);
+    setOutputs({ changed: 'true', version });
+  } else {
+    console.log('package.json version unchanged.');
+    setOutputs({ changed: 'false' });
+  }
+}

--- a/scripts/version-changed.test.js
+++ b/scripts/version-changed.test.js
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readVersion, versionChange } from './version-changed.js';
+
+describe('versionChange', () => {
+  it('reports the new version when it changed', () => {
+    assert.equal(
+      versionChange('{"version":"0.1.0"}', '{"version":"0.2.0"}'),
+      '0.2.0'
+    );
+  });
+  it('is null when unchanged', () => {
+    assert.equal(
+      versionChange('{"version":"0.1.0"}', '{"version":"0.1.0"}'),
+      null
+    );
+  });
+  it('treats a missing or unparsable parent as a change (first release)', () => {
+    assert.equal(versionChange('', '{"version":"0.1.0"}'), '0.1.0');
+    assert.equal(versionChange('not json', '{"version":"0.1.0"}'), '0.1.0');
+  });
+  it('never tags when the current version is unreadable', () => {
+    assert.equal(versionChange('{"version":"0.1.0"}', '{}'), null);
+    assert.equal(readVersion('{'), '');
+  });
+});


### PR DESCRIPTION
## What this changes

Picks up the versioning thread from #48. Contributors set the level in the PR, automation does the boring half, cutting a release stays your call.

- **PR template** gets a `## Changelog` block with three lines: `Bump: patch | minor | major | none`, `Category: Added | Changed | Fixed | Removed | Internal`, `Entry: one line`. A fork-safe check (`changelog-field.yml`, no secrets) validates it on every PR.
- **On merge to `main`**, `changelog.yml` finds the PR for the commit, drops the entry under `[Unreleased]`, and keeps the highest pending level as a `<!-- bump: … -->` marker. No version moves on merge.
- **Release** is a `workflow_dispatch` (`level` = `auto` | patch | minor | major). It rolls `[Unreleased]` into `## [x.y.z] - date`, bumps `package.json`, regenerates the README skills table, and opens a `release/vx.y.z` PR for you to merge. Merging it is what tags `vx.y.z` and publishes a GitHub Release built from that CHANGELOG section.
- **Skills table:** rows get sorted, new skills get a row seeded from the `Use when` clause in their `description`, removed skills drop out. Your hand-written "Use when" text is preserved as-is (the derived text was noticeably worse for the five it already had, so I stopped short of making frontmatter the source for that column). Running it here added the `maplibre-v6-migration` row from #53 (the table never got one) and put the rest in alphabetical order; that's the whole README diff. Process skills get a row like any other, matching how you listed `maplibre-skill-authoring`.

Scripts are plain node, no new deps, and the workflow shell is down to `git`/`gh` plumbing; the logic (PR lookup, version-change check, PR body, changelog edits) lives in `scripts/` with tests. I ran the whole chain on my fork with Actions on: throwaway PR with the field → merge → entry recorded → dispatch → release PR → merge → `v0.2.0` tag and Release. Then deleted all of it.

Two things it needs from repo settings, both in CONTRIBUTING now: "Allow GitHub Actions to create and approve pull requests" (Settings → Actions → General; for an org repo the org setting has to allow it first), or the release PR has to be opened by hand from the pushed branch; and since a PR opened with `GITHUB_TOKEN` doesn't trigger `check.yml`, the release PR shows no checks until it's closed and reopened. A PAT would fix the second; I left it on the built-in token, happy to switch if you'd rather.

PRs opened before this lands (#56, #59, #32) have no field; merging them logs a warning on the run and records nothing, so their entries are a hand edit. The PR-time check is the gate, merge time only reports.

Small side effect: `package-lock.json` still says `1.0.0` while `package.json` says `0.1.0`; the first release cut will bring it in line.

## How to review

`.github/PULL_REQUEST_TEMPLATE.md` and the "Versioning and the CHANGELOG" section in CONTRIBUTING.md are the contributor-facing bits. The three workflows are short and mostly `git`/`gh` calls; `scripts/lib/changelog-field.js` is the parser everything keys off. The tests are the fastest way to see what each script does to a CHANGELOG. The README diff is one added row (`maplibre-v6-migration`) plus alphabetical order.

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above (no skill content in this PR)
- [x] Claims are traceable to a primary source: [`GITHUB_TOKEN` events don't start workflow runs](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs), [the PR-creation setting](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests)

## Changelog

Bump: patch
Category: Internal
Entry: Versioning and CHANGELOG automation: a `Changelog` field in the PR template, entries recorded on merge, a Release workflow that cuts the version and regenerates the README skills table

## AI usage

Implementation drafted with Claude Code (Opus 4.6), from a written spec; every script, test, and workflow read and run locally by me; the PR description is my own.

