### PR TITLE
fix(skills): correct v6-breaking import/CDN examples in mapbox-migration and pmtiles-patterns

### DIFF
--- a/skills/maplibre-mapbox-migration/SKILL.md
+++ b/skills/maplibre-mapbox-migration/SKILL.md
@@ -35,7 +35,7 @@ Common reasons teams switch from Mapbox to MapLibre:
 
 - **Dec 2020:** Mapbox GL JS v2.0 switched to a proprietary license. The community forked v1.13 as **MapLibre GL JS**. [MapLibre organization](https://github.com/maplibre) and [GL JS repo](https://github.com/maplibre/maplibre-gl-js) are the canonical homes.
 - **API:** MapLibre GL JS v1.x is largely backward compatible with Mapbox GL JS v1.x. Most map code (methods, events, layers, sources) works with minimal changes.
-- **Releases since the fork:** MapLibre has moved ahead with its own version line. v2/v3 brought WebGL2, a modern renderer, and features like hillshade and terrain; v4 introduced Promises in public APIs (replacing many callbacks); v5 added globe view and the [Adaptive Composite Map Projection](https://maplibre.org/maplibre-gl-js/docs/API/). See [releases](https://github.com/maplibre/maplibre-gl-js/releases) and [CHANGELOG](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md).
+- **Releases since the fork:** MapLibre has moved ahead with its own version line. v2/v3 brought WebGL2, a modern renderer, and features like hillshade and terrain; v4 introduced Promises in public APIs (replacing many callbacks); v5 added globe view and the [Adaptive Composite Map Projection](https://maplibre.org/maplibre-gl-js/docs/API/); v6 (2026-07-22) ships as **ES modules only** — the UMD bundle and default export are gone (see [Update Imports and CSS](#2-update-imports-and-css) below) — and changed several defaults (see the [v5-to-v6 migration guide](https://maplibre.org/maplibre-gl-js/docs/guides/v5-to-v6-migration-guide/)). See [releases](https://github.com/maplibre/maplibre-gl-js/releases) and [CHANGELOG](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md).
 - **Style spec:** MapLibre maintains its own [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/) (forked from the Mapbox spec). It is compatible for most styles but has added and diverged in places; check the [style spec site](https://maplibre.org/maplibre-style-spec/) when using newer or MapLibre-specific features.
 - **Ecosystem:** Besides GL JS, the MapLibre org hosts [MapLibre Native](https://maplibre.org/projects/native/) (iOS, Android, desktop), [Martin](https://maplibre.org/martin/) (vector tile server from PostGIS/PMTiles/MBTiles), and the [MapLibre Tile (MLT)](https://maplibre.org/maplibre-tile-spec/) format. Roadmaps and news: [maplibre.org/roadmap](https://maplibre.org/roadmap/), [maplibre.org/news](https://maplibre.org/news/).
 
@@ -54,15 +54,28 @@ npm install maplibre-gl
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
-// After (MapLibre)
-import maplibregl from 'maplibre-gl';
+// After (MapLibre) — v6 ships ES modules only; the default export is gone
+import * as maplibregl from 'maplibre-gl';
+// or pull in just what you need: import {Map} from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 ```
 
-**CDN:** Replace Mapbox script/link with MapLibre:
+**CDN:** Replace Mapbox script/link with MapLibre. MapLibre v6 has no UMD bundle, so a bare
+`<script src>` tag no longer works — use a module script against the `.mjs` build instead:
 
-- Script: `https://api.mapbox.com/mapbox-gl-js/v*.*.*/mapbox-gl.js` → `https://unpkg.com/maplibre-gl@*.*.*/dist/maplibre-gl.js`
-- CSS: same pattern (mapbox-gl.css → maplibre-gl.css).
+```html
+<!-- Before (Mapbox) -->
+<script src="https://api.mapbox.com/mapbox-gl-js/v*.*.*/mapbox-gl.js"></script>
+<link href="https://api.mapbox.com/mapbox-gl-js/v*.*.*/mapbox-gl.css" rel="stylesheet" />
+
+<!-- After (MapLibre) -->
+<script type="module">
+  import * as maplibregl from 'https://unpkg.com/maplibre-gl@^6.0.0/dist/maplibre-gl.mjs';
+</script>
+<link href="https://unpkg.com/maplibre-gl@^6.0.0/dist/maplibre-gl.css" rel="stylesheet" />
+```
+
+If you were pinned to a MapLibre v5 CDN script tag, the same swap applies: `dist/maplibre-gl.js` → `type="module"` importing `dist/maplibre-gl.mjs`.
 
 ### 3. Replace the Namespace
 

--- a/skills/maplibre-mapbox-migration/SKILL.md
+++ b/skills/maplibre-mapbox-migration/SKILL.md
@@ -60,22 +60,23 @@ import * as maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 ```
 
-**CDN:** Replace Mapbox script/link with MapLibre. MapLibre v6 has no UMD bundle, so a bare
-`<script src>` tag no longer works — use a module script against the `.mjs` build instead:
+**CDN:** Replace Mapbox script/link with MapLibre. Don't assume Mapbox's `<script src>`
+pattern carries over unchanged — MapLibre's distributed bundle formats have changed across
+major versions (v6 dropped the UMD build). Check the
+[current release notes](https://github.com/maplibre/maplibre-gl-js/releases) before copying
+this snippet as-is:
 
 ```html
 <!-- Before (Mapbox) -->
 <script src="https://api.mapbox.com/mapbox-gl-js/v*.*.*/mapbox-gl.js"></script>
 <link href="https://api.mapbox.com/mapbox-gl-js/v*.*.*/mapbox-gl.css" rel="stylesheet" />
 
-<!-- After (MapLibre) -->
+<!-- After (MapLibre, current as of v6) -->
 <script type="module">
   import * as maplibregl from 'https://unpkg.com/maplibre-gl@^6.0.0/dist/maplibre-gl.mjs';
 </script>
 <link href="https://unpkg.com/maplibre-gl@^6.0.0/dist/maplibre-gl.css" rel="stylesheet" />
 ```
-
-If you were pinned to a MapLibre v5 CDN script tag, the same swap applies: `dist/maplibre-gl.js` → `type="module"` importing `dist/maplibre-gl.mjs`.
 
 ### 3. Replace the Namespace
 

--- a/skills/maplibre-pmtiles-patterns/SKILL.md
+++ b/skills/maplibre-pmtiles-patterns/SKILL.md
@@ -50,7 +50,7 @@ npm install pmtiles
 
 ```javascript
 import * as pmtiles from 'pmtiles';
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 // Add PMTiles protocol so sources can reference .pmtiles URLs


### PR DESCRIPTION
## What this changes

Fixes two skills against MapLibre GL JS v6, which ships ES modules only. 

## The gap it closes

Currently, `maplibre-mapbox-migration` and `maplibre-pmtiles-patterns` teach the now-broken default import; mapbox-migration also pointed at a bare `<script src>` CDN tag and had no v6 line in its version history.

## How to review

Read the two `SKILL.md` diffs for factual accuracy. No new eval run.

## Checks

- [x] `npm run check` passes
- [x] Claims are traceable to a primary source (v6 release notes, the official v5-to-v6 migration guide, `src/ui/map.ts`)

## AI usage

AI-Generated by: Claude Sonnet 5 (under supervision)

- [x] I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself
