### PR TITLE
fix(evals): open an issue when the publish job fails after a passing eval

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -216,6 +216,33 @@ jobs:
               labels: ['skill-status-change']
             })
 
+      # The eval passed but publishing its results did not (push rejected, sync
+      # threw, artifact download flaked). Distinct from the drift issue below,
+      # which covers the eval job itself; guarded so a failed eval opens one issue, not two.
+      - name: Open issue on publish failure
+        if: failure() && needs.eval.result == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Eval publish step failed — ${date}`,
+              body: [
+                `The weekly eval ran and passed, but the publish job failed after it, so the results CSVs and any status flip may not have landed.`,
+                ``,
+                `[Workflow run](${run})`,
+                ``,
+                `Check the failed step in the run log:`,
+                `- **Commit results / Commit status changes** — a rejected \`git push\` usually means \`main\` moved during the run; re-running the workflow is enough.`,
+                `- **Sync skill status** — \`scripts/sync-skill-status.js\` threw; the log has the reason.`,
+                `- **Download results / Download verdicts** — the artifact upload or download flaked; re-run.`,
+              ].join('\n'),
+              labels: ['eval-publish']
+            })
+
       # This run watches for drift — a provider silently updating a model behind a
       # pinned ID. So the issue asks a question; it does not assert a cause.
       - name: Open issue on failure


### PR DESCRIPTION
## What this changes

Closes #55, going with the first of your two options. The `publish` job gets its own `Open issue on publish failure` step: `if: failure() && needs.eval.result == 'success'`. The guard matters because `failure()` is also true when an ancestor job failed, so without it a failed eval would open two issues; with it, eval failures still go to your drift issue and only a passing-eval-then-broken-publish lands here, labeled `eval-publish`. The issue body names the three steps that can fail in that job and what each usually means (a rejected push after `main` moved → re-run; `sync-skill-status.js` threw → the log; artifact download flaked → re-run).

Labels: none of `eval-drift`, `skill-status-change`, or `eval-publish` exist in the repo yet; the API creates a label on first use (checked on my fork), so nothing to set up.

## How to review

One step, 27 lines, in `eval.yml`, right above your `Open issue on failure`. `actionlint` is clean; the scheduled path is the part I can't exercise from a fork.

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above (no skill content)
- [x] Claims are traceable to a primary source: [`failure()` in the expressions reference](https://docs.github.com/en/actions/learn-github-actions/expressions#failure)

## Changelog

Bump: patch
Category: Internal
Entry: `eval.yml`: a publish-job failure after a passing eval now opens an `eval-publish` issue (#55)

## AI usage

- [x] Change drafted with Claude Code from Stephanie's issue text. I read the step, ran actionlint and npm run check. The description is my own.
