### PR TITLE
docs(contributing): document the model-pins check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,8 @@ Run `npm run check` frequently while developing, not just before pushing — it 
 2. **Spelling** — cspell (markdown)
 3. **Markdown linting** — markdownlint
 4. **Terminology** — proper noun capitalization (e.g. `MapLibre` not `Maplibre`)
-5. **Skills validation** — YAML frontmatter and structure
+5. **Model pins** — provider ids must match the pinned generator/judge
+6. **Skills validation** — YAML frontmatter and structure
 
 All checks pass when the output ends with:
 


### PR DESCRIPTION
## Summary
- `npm run check` runs six steps but `CONTRIBUTING.md`'s Checks section only listed five, never mentioning the model-pin lint (`lint:model-pins` / `scripts/model-pin-check.js`) that shipped in #47.
- Adds it as item 5 in the numbered list.

## Changelog

Bump: none

## Test plan
- [x] `npm run check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By4UgaboRHbVvifFH3JA2R