### PR TITLE
ci(release-watch): file an issue when an upstream release contradicts a skill

### DIFF
--- a/.github/release-watch/state.json
+++ b/.github/release-watch/state.json
@@ -1,0 +1,30 @@
+{
+  "maplibre/maplibre-gl-js": {
+    "tag": "v6.6.0",
+    "published_at": "2026-08-24T15:15:59Z"
+  },
+  "maplibre/maplibre-style-spec": {
+    "tag": "v26.4.1",
+    "published_at": "2026-08-25T21:44:45Z"
+  },
+  "maplibre/maplibre-native": {
+    "tag": "android-v13.6.0",
+    "published_at": "2026-08-28T13:38:55Z"
+  },
+  "maplibre/martin": {
+    "tag": "martin-v1.14.0",
+    "published_at": "2026-08-18T14:06:17Z"
+  },
+  "maplibre/maplibre-tile-spec": {
+    "tag": "rust-mlt-wasm-v0.1.20",
+    "published_at": "2026-08-21T10:15:18Z"
+  },
+  "felt/tippecanoe": {
+    "tag": "2.79.0",
+    "published_at": "2025-07-24T20:22:00Z"
+  },
+  "onthegomap/planetiler": {
+    "tag": "v0.10.2",
+    "published_at": "2026-03-29T01:02:12Z"
+  }
+}

--- a/.github/release-watch/watch.yml
+++ b/.github/release-watch/watch.yml
@@ -8,30 +8,31 @@
 # it has no skill surface, it does not belong here.
 #
 # Read by scripts/lib/release-watch.js, which understands a deliberately small
-# slice of YAML: a `watch:` list of entries, each a flat map of single-line
-# values (repo, why, enabled, note). No block scalars, no nesting.
+# slice of YAML: a `watch:` list of entries, each a flat map of scalar values
+# (repo, why, enabled, note). A quoted value may wrap onto following lines; no
+# block scalars, no nesting.
 
 watch:
   - repo: maplibre/maplibre-gl-js
-    why: 'maplibre-mapbox-migration, maplibre-v6-migration, maplibre-pmtiles-patterns, maplibre-terrain-patterns and maplibre-fonts-glyphs all carry GL JS import paths, CDN bundle names, map options and API calls.'
+    why: 'Every skill except maplibre-skill-authoring calls the GL JS API; maplibre-mapbox-migration, maplibre-v6-migration, maplibre-pmtiles-patterns and maplibre-fonts-glyphs also carry its import paths and CDN bundle names.'
 
   - repo: maplibre/maplibre-style-spec
-    why: 'maplibre-cartography, maplibre-terrain-patterns and maplibre-fonts-glyphs name style properties, expressions and source types that the spec defines.'
+    why: 'maplibre-cartography, maplibre-terrain-patterns and maplibre-fonts-glyphs name style properties, expressions, source types (raster-dem) and the glyphs URL template that the spec defines.'
 
   - repo: maplibre/maplibre-native
-    why: 'maplibre-cartography and maplibre-fonts-glyphs describe rendering behavior shared with Native; style and glyph handling changes land here first for mobile.'
+    why: 'maplibre-fonts-glyphs names the Native-only font-faces property, the Android and iOS versions that ship it, and the open issue for local-font fallback (maplibre-native#165).'
 
   - repo: maplibre/martin
-    why: 'maplibre-tile-sources and maplibre-pmtiles-patterns name Martin endpoints, configuration keys and command-line flags.'
+    why: 'maplibre-pmtiles-patterns says Martin serves PMTiles from local paths, HTTP URLs and S3 and names martin-cp; maplibre-tile-sources says Martin exposes MBTiles/PMTiles metadata as TileJSON; maplibre-cartography lists it as a sprite generator.'
 
   - repo: maplibre/maplibre-tile-spec
-    why: 'maplibre-tile-sources describes MLT as a tile format; its encodings and tooling names are still moving.'
+    why: 'maplibre-tile-sources and maplibre-mapbox-migration name MLT as a vector tile format and link the spec.'
 
   - repo: felt/tippecanoe
-    why: 'maplibre-tile-sources gives tippecanoe command lines; its flags are the part most likely to go stale.'
+    why: 'maplibre-pmtiles-patterns gives tippecanoe command lines (-zg, -o, -z) and says PMTiles output arrived in v2.17; maplibre-tile-sources recommends it for vector tiles.'
 
   - repo: onthegomap/planetiler
-    why: 'maplibre-tile-sources recommends planetiler for planet-scale builds and names its command-line options.'
+    why: 'maplibre-pmtiles-patterns gives a planetiler command line (--area, --output) and names the OpenMapTiles schema; maplibre-tile-sources recommends it for vector tiles from OSM.'
 
   # Protomaps publishes the PMTiles specification and the JavaScript library, but
   # this repository has no GitHub Releases and no tags at all (verified against

--- a/.github/release-watch/watch.yml
+++ b/.github/release-watch/watch.yml
@@ -1,0 +1,44 @@
+# The repositories the release watch reads, and why each one is on the list.
+#
+# Explicit and reviewable on purpose. Deriving it from the MapLibre org would
+# miss the ecosystem projects our skills make claims about (Protomaps,
+# tippecanoe, planetiler) and would pull in org repos no skill touches.
+#
+# Adding an entry: name the repo, and say which skill's claims depend on it. If
+# it has no skill surface, it does not belong here.
+#
+# Read by scripts/lib/release-watch.js, which understands a deliberately small
+# slice of YAML: a `watch:` list of entries, each a flat map of single-line
+# values (repo, why, enabled, note). No block scalars, no nesting.
+
+watch:
+  - repo: maplibre/maplibre-gl-js
+    why: 'maplibre-mapbox-migration, maplibre-v6-migration, maplibre-pmtiles-patterns, maplibre-terrain-patterns and maplibre-fonts-glyphs all carry GL JS import paths, CDN bundle names, map options and API calls.'
+
+  - repo: maplibre/maplibre-style-spec
+    why: 'maplibre-cartography, maplibre-terrain-patterns and maplibre-fonts-glyphs name style properties, expressions and source types that the spec defines.'
+
+  - repo: maplibre/maplibre-native
+    why: 'maplibre-cartography and maplibre-fonts-glyphs describe rendering behavior shared with Native; style and glyph handling changes land here first for mobile.'
+
+  - repo: maplibre/martin
+    why: 'maplibre-tile-sources and maplibre-pmtiles-patterns name Martin endpoints, configuration keys and command-line flags.'
+
+  - repo: maplibre/maplibre-tile-spec
+    why: 'maplibre-tile-sources describes MLT as a tile format; its encodings and tooling names are still moving.'
+
+  - repo: felt/tippecanoe
+    why: 'maplibre-tile-sources gives tippecanoe command lines; its flags are the part most likely to go stale.'
+
+  - repo: onthegomap/planetiler
+    why: 'maplibre-tile-sources recommends planetiler for planet-scale builds and names its command-line options.'
+
+  # Protomaps publishes the PMTiles specification and the JavaScript library, but
+  # this repository has no GitHub Releases and no tags at all (verified against
+  # the API 2026-08-28), so there is nothing for the watch to read. The PMTiles
+  # claims in maplibre-pmtiles-patterns are watched indirectly through GL JS.
+  # Enable this entry if Protomaps starts cutting releases here.
+  - repo: protomaps/PMTiles
+    enabled: false
+    note: 'publishes no GitHub Releases or tags; nothing to watch yet'
+    why: 'maplibre-pmtiles-patterns depends on the PMTiles archive spec, protocol registration and the js library API.'

--- a/.github/workflows/release-watch.yml
+++ b/.github/workflows/release-watch.yml
@@ -1,0 +1,112 @@
+name: Release watch
+
+## Reads the releases of the repositories in .github/release-watch/watch.yml and
+## files an issue when one of them removed, renamed, or deprecated something a
+## skill still mentions. Triggered by:
+#   - schedule: weekly, a few hours after the eval drift check.
+#   - workflow_dispatch: a maintainer catching up on a release the same day.
+#       repo     – limit to one watch-list entry. Blank = the whole list.
+#       tag      – examine exactly this release, ignoring the watermark.
+#       dry-run  – print what it would file and write nothing.
+#
+# Needs no third-party secrets and makes no model calls: GITHUB_TOKEN is the
+# whole credential surface. It files issues for a human to read. It never opens
+# a pull request, never edits a skill file, and never closes an issue.
+#
+# See CONTRIBUTING.md -> "Release watch" for the matching rules and how to run
+# it locally.
+
+on:
+  schedule:
+    - cron: '43 13 * * 0' # Sunday 13:43 UTC: after the eval drift check, off-:00 so GitHub doesn't drop it
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Limit to one watch-list repo, e.g. maplibre/maplibre-gl-js (blank = all)'
+        required: false
+        default: ''
+      tag:
+        description: 'Examine exactly this release tag, ignoring the watermark'
+        required: false
+        default: ''
+      dry-run:
+        description: 'Print what would be filed and write nothing'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # files the reports
+      contents: write # commits the advanced watermark
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Inputs go through env rather than into the command line, so a dispatch
+      # value is data to the shell, never part of it.
+      - name: Run the release watch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set --
+          if [ -n "$INPUT_REPO" ]; then set -- "$@" --repo "$INPUT_REPO"; fi
+          if [ -n "$INPUT_TAG" ]; then set -- "$@" --tag "$INPUT_TAG"; fi
+          if [ "$INPUT_DRY_RUN" = "true" ]; then set -- "$@" --dry-run; fi
+          node scripts/release-watch.js "$@"
+
+      # The watermark is what makes a rerun idempotent and a missed week catch
+      # up. Committed only on the scheduled run: a dispatch is a maintainer
+      # looking at one release, and should not move the shared watermark.
+      - name: Commit the watermark
+        if: github.event_name == 'schedule'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/release-watch/state.json
+          git diff --staged --quiet || git commit -m "chore(release-watch): advance the watermark"
+          git push
+
+      # The watch failing is not the same as a skill being stale — it means the
+      # check did not run. Say so, rather than letting a silent week look clean.
+      - name: Open issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Release watch failed — ${date}`,
+              body: [
+                `The weekly release watch did not complete, so no upstream releases were checked against the skills this week.`,
+                ``,
+                `[Workflow run](${run})`,
+                ``,
+                `Common causes, in order:`,
+                `1. **A watch-list repo moved or went private** — the run log names the repo it could not read. Fix or disable its entry in \`.github/release-watch/watch.yml\`.`,
+                `2. **A rejected \`git push\`** on the watermark commit — \`main\` moved during the run; re-running is enough.`,
+                `3. **Rate limiting** — re-run.`,
+                ``,
+                `The watermark only advances on a successful run, so a re-run picks up everything the failed one would have seen.`,
+              ].join('\n'),
+              labels: ['release-watch']
+            })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,36 @@ On merge, automation reads these fields and inserts the entry under `[Unreleased
 
 Releases are cut by a maintainer via the Release workflow (`workflow_dispatch`), which bumps the version, moves `[Unreleased]` entries into a dated section, regenerates the README skills table, and opens a release PR. Merging that PR tags `vX.Y.Z` and publishes the GitHub Release. Opening the PR needs "Allow GitHub Actions to create and approve pull requests" enabled under Settings → Actions → General → Workflow permissions; without it the workflow pushes the `release/vX.Y.Z` branch and stops, and the PR can be opened by hand. A PR opened by the workflow does not trigger `check.yml` on its own (GitHub does not run workflows for events caused by `GITHUB_TOKEN`); close and reopen it to run the checks. The README skills table is regenerated at the same time: rows are sorted by name, a row is added for each new skill (its "Use when" text seeded from the `Use when` clause of the skill's `description`), and rows for removed skills are dropped. Existing "Use when" text is preserved, so edit it in place in `README.md` whenever it can be improved; there is no need to touch the table when adding a skill.
 
+### Release watch
+
+Skills go stale when an upstream project removes something they still recommend. MapLibre GL JS v6 stopped publishing the UMD bundle, and a skill kept pointing at `dist/maplibre-gl.js` for two weeks before a user reported it. The Release watch workflow (`.github/workflows/release-watch.yml`) is the check for that: weekly, plus `workflow_dispatch` for a maintainer catching up on a release the same day.
+
+It reports two plain facts — what a release note says, and what our files contain. It never asserts that a model gets something wrong; only a baseline eval can establish that. It files an issue for a human to read, and by design it never opens a pull request, never edits a skill file, and never closes an issue. It needs no API keys and makes no model calls.
+
+**The watch list** is `.github/release-watch/watch.yml`: explicit and committed, each entry naming a repository and which skills' claims depend on it. It is not derived from the MapLibre organization, because skills make claims about ecosystem projects outside it. If a project has no skill surface, it does not belong on the list. `.github/release-watch/state.json` is the watermark — the last release read per repository — so a rerun files nothing twice and a missed week catches up instead of skipping.
+
+**What it flags.** For each release newer than the watermark (drafts and prereleases skipped, which is how per-commit test builds stay out), it reads the notes that announce a removal, rename, or deprecation:
+
+- every note under a heading whose text mentions breaking, removed, removal, deprecation, incompatibility, or migration;
+- any note marked ⚠️, 💥, or `BREAKING CHANGE` wherever it sits — GL JS marks its breaking changes this way, under an ordinary "Features and improvements" heading, so a heading-only reader would have missed the v6 case entirely;
+- any note containing one of a fixed list of phrases (`no longer published`, `has been removed`, `is deprecated`, `renamed to`, and so on — see `scripts/lib/release-watch.js`).
+
+From those notes it takes only what the author put in backticks, on the reasoning that a code span is a name marked machine-readable while prose matches far too much. A span containing spaces is a snippet matched verbatim (`import maplibregl from 'maplibre-gl'`); a span without spaces is an identifier matched on word boundaries (`maplibre-gl.js`, `--tile-format=mlt`). Identifiers that are short bare words are dropped, since a rename note names its surrounding types as context and matching those floods the report with lines that are still correct.
+
+Every match is then reported as `file:line` beside the release note that contradicts it, in one issue per release labeled `release-watch` and `needs-triage`. A release with no matches files nothing — an issue per release either way would bury the ones that matter — but it is listed in the workflow run summary as read. The matches are string matches, not verified defects: some are content to correct, and some are mentions that are still accurate in context.
+
+**Running it yourself.** `--dry-run` prints the issues it would file and writes nothing. To reproduce the v6 case against the content as it stood before the fix in [#59](https://github.com/maplibre/maplibre-agent-skills/pull/59):
+
+```bash
+rm -rf /tmp/release-watch-pre59 && mkdir -p /tmp/release-watch-pre59
+git archive 23e583e^ skills | tar -x -C /tmp/release-watch-pre59
+node scripts/release-watch.js --dry-run --repo maplibre/maplibre-gl-js --tag v6.0.0 --skills-dir /tmp/release-watch-pre59/skills
+```
+
+It flags `maplibre-mapbox-migration/SKILL.md:64` on `maplibre-gl.js` and both that skill and `maplibre-pmtiles-patterns/SKILL.md:53` on `import maplibregl from 'maplibre-gl'` — the two examples #59 corrected. Run the same command with no `--skills-dir` and those matches are gone from current content; what is left in both files is the replacement form, which that release note also quotes. That is the one known false positive, and it is why the issue calls its output matches rather than defects.
+
+This is a Class A check only: content of ours that a release contradicts. It says nothing about features a pre-cutoff model would not know (which needs a baseline eval) or content a newer model already gets right (which needs committed baseline probes). Keeping those apart is what keeps the output from reading as an undifferentiated stream of findings.
+
 ## Note on AI usage
 
 Please take a moment to review [MapLibre's AI Policy](https://github.com/maplibre/maplibre/blob/main/AI_POLICY.md). tl;dr: do not let AI speak for you, verify all generated content before requesting a review, and disclose AI usage in pull requests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,17 +240,17 @@ Releases are cut by a maintainer via the Release workflow (`workflow_dispatch`),
 
 ### Release watch
 
-Skills go stale when an upstream project removes something they still recommend. MapLibre GL JS v6 stopped publishing the UMD bundle, and a skill kept pointing at `dist/maplibre-gl.js` for two weeks before a user reported it. The Release watch workflow (`.github/workflows/release-watch.yml`) is the check for that: weekly, plus `workflow_dispatch` for a maintainer catching up on a release the same day.
+Skills go stale when an upstream project removes something they still recommend. MapLibre GL JS v6.0.0 (2026-07-22) stopped publishing the UMD bundle, and a skill kept pointing at `dist/maplibre-gl.js` for over three weeks, until the v6 fallout tracking issue ([maplibre-gl-js#8168](https://github.com/maplibre/maplibre-gl-js/issues/8168)) listed this repository among the places to fix. The Release watch workflow (`.github/workflows/release-watch.yml`) is the check for that: weekly, plus `workflow_dispatch` for a maintainer catching up on a release the same day.
 
 It reports two plain facts — what a release note says, and what our files contain. It never asserts that a model gets something wrong; only a baseline eval can establish that. It files an issue for a human to read, and by design it never opens a pull request, never edits a skill file, and never closes an issue. It needs no API keys and makes no model calls.
 
 **The watch list** is `.github/release-watch/watch.yml`: explicit and committed, each entry naming a repository and which skills' claims depend on it. It is not derived from the MapLibre organization, because skills make claims about ecosystem projects outside it. If a project has no skill surface, it does not belong on the list. `.github/release-watch/state.json` is the watermark — the last release read per repository — so a rerun files nothing twice and a missed week catches up instead of skipping.
 
-**What it flags.** For each release newer than the watermark (drafts and prereleases skipped, which is how per-commit test builds stay out), it reads the notes that announce a removal, rename, or deprecation:
+**What it flags.** For each release newer than the watermark (drafts and prereleases skipped, which is how tippecanoe's per-commit test builds stay out), it reads the notes that announce a removal, rename, or deprecation:
 
 - every note under a heading whose text mentions breaking, removed, removal, deprecation, incompatibility, or migration;
-- any note marked ⚠️, 💥, or `BREAKING CHANGE` wherever it sits — GL JS marks its breaking changes this way, under an ordinary "Features and improvements" heading, so a heading-only reader would have missed the v6 case entirely;
-- any note containing one of a fixed list of phrases (`no longer published`, `has been removed`, `is deprecated`, `renamed to`, and so on — see `scripts/lib/release-watch.js`).
+- any note marked ⚠️, 💥, `BREAKING CHANGE`, or `[breaking]` wherever it sits — GL JS marks its breaking changes with the warning emoji under an ordinary "Features and improvements" heading, and Planetiler prefixes bullets with `[breaking]`, so a heading-only reader would have missed the v6 case entirely;
+- any note containing one of a fixed list of phrases (`no longer published`, `has been removed`, `is deprecated`, `renamed to`, and so on), or a removal verb (remove, rename, drop, deprecate) directly before a code span — see `scripts/lib/release-watch.js`.
 
 From those notes it takes only what the author put in backticks, on the reasoning that a code span is a name marked machine-readable while prose matches far too much. A span containing spaces is a snippet matched verbatim (`import maplibregl from 'maplibre-gl'`); a span without spaces is an identifier matched on word boundaries (`maplibre-gl.js`, `--tile-format=mlt`). Identifiers that are short bare words are dropped, since a rename note names its surrounding types as context and matching those floods the report with lines that are still correct.
 
@@ -264,7 +264,11 @@ git archive 23e583e^ skills | tar -x -C /tmp/release-watch-pre59
 node scripts/release-watch.js --dry-run --repo maplibre/maplibre-gl-js --tag v6.0.0 --skills-dir /tmp/release-watch-pre59/skills
 ```
 
-It flags `maplibre-mapbox-migration/SKILL.md:64` on `maplibre-gl.js` and both that skill and `maplibre-pmtiles-patterns/SKILL.md:53` on `import maplibregl from 'maplibre-gl'` — the two examples #59 corrected. Run the same command with no `--skills-dir` and those matches are gone from current content; what is left in both files is the replacement form, which that release note also quotes. That is the one known false positive, and it is why the issue calls its output matches rather than defects.
+Among its hits are `maplibre-mapbox-migration/SKILL.md:64` on `maplibre-gl.js` and `maplibre-mapbox-migration/SKILL.md:58` plus `maplibre-pmtiles-patterns/SKILL.md:53` on `import maplibregl from 'maplibre-gl'` — the examples #59 corrected. Run the same command with no `--skills-dir` and those three are gone from current content; what remains in both files is the replacement forms, which that release note also quotes.
+
+The rest of that report shows the two kinds of noise to expect. Most of its roughly forty matches land in `maplibre-v6-migration`, which documents the removed names on purpose — a migration skill matches its own release by design. And a ⚠️ on a v6 bug fix about `line-color` matches ordinary style examples, because the marker is read as breaking no matter what the note says. Both are quick for a maintainer to dismiss, and they are why the issue calls its output matches rather than defects.
+
+If a watched repository cannot be read (moved, private, rate-limited), that repository's watermark stays put, the rest of the list is still checked, and the run fails at the end so the failure issue is opened rather than a clean-looking week going by; the next run reads the same releases again, and the marker in each filed issue keeps a rerun from filing twice. A release edited after it was published is not re-read: the watermark is its `published_at`, which an edit does not change.
 
 This is a Class A check only: content of ours that a release contradicts. It says nothing about features a pre-cutoff model would not know (which needs a baseline eval) or content a newer model already gets right (which needs committed baseline probes). Keeping those apart is what keeps the output from reading as an undifferentiated stream of findings.
 

--- a/scripts/lib/release-watch.js
+++ b/scripts/lib/release-watch.js
@@ -1,0 +1,419 @@
+/**
+ * Pure functions behind the release watch (`scripts/release-watch.js`).
+ *
+ * The job: given an upstream release body, decide which of its notes announce a
+ * removal, rename, or deprecation, pull the machine-readable names out of those
+ * notes, and report where those names still appear in our skill files. Nothing
+ * here talks to the network or the filesystem, so it can all be tested against
+ * fixture release bodies.
+ *
+ * The rules below were written against real release bodies (MapLibre GL JS v6,
+ * Martin, planetiler, tippecanoe), not against an idea of what a release body
+ * looks like. The important finding: GL JS does not put its breaking changes
+ * under a "Breaking changes" heading. It marks individual bullets with a warning
+ * emoji and leaves them under "Features and improvements". A heading-only reader
+ * would have missed the v6 UMD removal entirely, which is the case this exists
+ * to catch.
+ */
+
+/** Headings whose section is read as breaking. Matched on the lowercased heading text. */
+const BREAKING_HEADING_WORDS = [
+  'breaking',
+  'removed',
+  'removal',
+  'deprecat',
+  'incompatib',
+  'migration'
+];
+
+/** Per-bullet markers that make a single note breaking wherever it sits. */
+const BREAKING_MARKERS = ['⚠', '💥', 'BREAKING CHANGE', 'BREAKING:'];
+
+/**
+ * Fixed phrases that make a note breaking on their own. A fixed list, not a
+ * guess at verb forms: a note has to say one of these things to be picked up,
+ * which keeps a routine "improve X" bullet from being read as a removal.
+ */
+const REMOVAL_PHRASES = [
+  'no longer published',
+  'no longer supported',
+  'no longer available',
+  'no longer required',
+  'has been removed',
+  'have been removed',
+  'was removed',
+  'were removed',
+  'is removed',
+  'are removed',
+  'support has been removed',
+  'dropped support',
+  'is deprecated',
+  'are deprecated',
+  'now deprecated',
+  'has been renamed',
+  'have been renamed',
+  'renamed to',
+  'replaced by',
+  'must switch to'
+];
+
+/**
+ * Names too common in this ecosystem to discriminate: every skill mentions them,
+ * so a hit on one says nothing. Kept short and explicit rather than tuned.
+ */
+const GENERIC_IDENTIFIERS = new Set([
+  'maplibre',
+  'maplibre-gl',
+  'mapbox',
+  'mapbox-gl',
+  'pmtiles',
+  'martin',
+  'style.json',
+  'https',
+  'http',
+  'import',
+  'export',
+  'require',
+  'return',
+  'const',
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'array',
+  'function',
+  'undefined',
+  'null',
+  'true',
+  'false',
+  'default',
+  'null'
+]);
+
+const MIN_IDENTIFIER_LENGTH = 5;
+
+/**
+ * A bare word this short or shorter has to earn its place some other way. A
+ * rename note names the surrounding types as context (`Map`, `Camera`, `Style`,
+ * `Marker`), and matching those floods the report with lines that are still
+ * correct. A name carrying `.`, `-`, `_`, `/` or `=` is specific enough on its
+ * own (`map.transform`, `maplibre-gl.js`, `--tile-format=mlt`); a plain word has
+ * to be long enough to be unmistakable (`styleimagemissing`, `MapDataEvent`).
+ */
+const MIN_BARE_WORD_LENGTH = 12;
+
+/** Hits per issue. Past this the report stops being readable; the rest wait for the next run. */
+export const MAX_HITS = 60;
+
+function headingLevel(line) {
+  const match = /^(#{1,6})\s+(.*)$/.exec(line);
+  return match ? { level: match[1].length, text: match[2].trim() } : null;
+}
+
+function isBreakingHeading(text) {
+  const lowered = text.toLowerCase();
+  return BREAKING_HEADING_WORDS.some((word) => lowered.includes(word));
+}
+
+function isListItem(line) {
+  return /^ {0,3}[-*+]\s+/.test(line);
+}
+
+/**
+ * Splits a release body into notes: one per top-level list item (continuation
+ * lines folded in) plus, inside a breaking section, each prose paragraph. Each
+ * note carries the heading it sat under so the issue can quote its context.
+ */
+export function splitNotes(body) {
+  const lines = String(body ?? '').split(/\r?\n/);
+  const notes = [];
+  let heading = '';
+  let breakingSection = false;
+  let breakingLevel = 0;
+  let current = null;
+
+  const flush = () => {
+    if (current && current.text.trim()) notes.push(current);
+    current = null;
+  };
+
+  for (const line of lines) {
+    const h = headingLevel(line);
+    if (h) {
+      flush();
+      heading = h.text;
+      if (isBreakingHeading(h.text)) {
+        breakingSection = true;
+        breakingLevel = h.level;
+      } else if (breakingSection && h.level <= breakingLevel) {
+        breakingSection = false;
+      }
+      continue;
+    }
+
+    if (isListItem(line)) {
+      flush();
+      current = {
+        heading,
+        inBreakingSection: breakingSection,
+        text: line.replace(/^ {0,3}[-*+]\s+/, '').trim()
+      };
+      continue;
+    }
+
+    if (!line.trim()) {
+      flush();
+      continue;
+    }
+
+    if (current) {
+      current.text += ' ' + line.trim();
+    } else if (breakingSection) {
+      current = { heading, inBreakingSection: true, text: line.trim() };
+    }
+  }
+  flush();
+  return notes;
+}
+
+export function isBreakingNote(note) {
+  if (note.inBreakingSection) return true;
+  if (BREAKING_MARKERS.some((marker) => note.text.includes(marker)))
+    return true;
+  const lowered = note.text.toLowerCase();
+  return REMOVAL_PHRASES.some((phrase) => lowered.includes(phrase));
+}
+
+/** The notes in a release body that announce a removal, rename, or deprecation. */
+export function breakingNotes(body) {
+  const seen = new Set();
+  return splitNotes(body)
+    .filter(isBreakingNote)
+    .filter((note) => {
+      if (seen.has(note.text)) return false;
+      seen.add(note.text);
+      return true;
+    });
+}
+
+function isUsefulIdentifier(token) {
+  if (token.length < MIN_IDENTIFIER_LENGTH) return false;
+  if (!/[A-Za-z]/.test(token)) return false;
+  if (/^v?\d/.test(token)) return false; // version numbers, not names
+  if (token.includes('://')) return false; // URLs, matched by their own text elsewhere
+  if (!/[.\-_/=]/.test(token) && token.length < MIN_BARE_WORD_LENGTH) {
+    return false;
+  }
+  return !GENERIC_IDENTIFIERS.has(token.toLowerCase());
+}
+
+/**
+ * Pulls searchable terms out of a note's inline code spans, and only out of
+ * those: a code span is the release author explicitly marking a machine-readable
+ * name, while prose words match far too much to be worth a maintainer's time.
+ *
+ * A span containing whitespace is a snippet, kept whole and matched verbatim
+ * (`import maplibregl from 'maplibre-gl'`). A span without whitespace is an
+ * identifier (`maplibre-gl.js`, `--tile-format=mlt`) and is matched on word
+ * boundaries, after dropping the too-generic and version-like ones.
+ *
+ * Known limitation: a note that quotes both the removed form and its
+ * replacement yields both, so corrected content can still match on the
+ * replacement. Nothing in the prose separates the two mechanically, and the
+ * report is explicit that its matches are matches, not defects.
+ */
+export function extractTerms(text) {
+  const spans = [...String(text ?? '').matchAll(/`([^`\n]+)`/g)].map((m) =>
+    m[1].trim()
+  );
+  const terms = [];
+  const seen = new Set();
+  for (const span of spans) {
+    if (!span) continue;
+    const kind = /\s/.test(span) ? 'phrase' : 'identifier';
+    if (kind === 'identifier' && !isUsefulIdentifier(span)) continue;
+    if (seen.has(span)) continue;
+    seen.add(span);
+    terms.push({ value: span, kind });
+  }
+  return terms;
+}
+
+const BOUNDARY = /[A-Za-z0-9_]/;
+
+/** True when `term` occurs in `line`; identifiers additionally require word boundaries. */
+export function lineMatches(line, term) {
+  if (term.kind === 'phrase') return line.includes(term.value);
+  let from = 0;
+  for (;;) {
+    const at = line.indexOf(term.value, from);
+    if (at === -1) return false;
+    const before = at === 0 ? '' : line[at - 1];
+    const after = line[at + term.value.length] ?? '';
+    if (!BOUNDARY.test(before) && !BOUNDARY.test(after)) return true;
+    from = at + 1;
+  }
+}
+
+/**
+ * Class A hits: for each breaking note in a release, every skill line that still
+ * contains one of its terms.
+ *
+ * `files` is `[{ path, content }]`. Returns `[{ note, term, path, line, text }]`.
+ */
+export function findHits(body, files) {
+  const hits = [];
+  for (const note of breakingNotes(body)) {
+    for (const term of extractTerms(note.text)) {
+      for (const file of files) {
+        const lines = file.content.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          if (!lineMatches(lines[i], term)) continue;
+          hits.push({
+            note: note.text,
+            heading: note.heading,
+            term: term.value,
+            kind: term.kind,
+            path: file.path,
+            line: i + 1,
+            text: lines[i].trim()
+          });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+/** The stable per-release marker that makes a rerun idempotent. */
+export function issueMarker(repo, tag) {
+  return `<!-- release-watch: ${repo}@${tag} -->`;
+}
+
+export function issueTitle(repo, tag) {
+  return `Release watch: ${repo} ${tag} may contradict skill content`;
+}
+
+function groupBy(hits, key) {
+  const map = new Map();
+  for (const hit of hits) {
+    const k = key(hit);
+    if (!map.has(k)) map.set(k, []);
+    map.get(k).push(hit);
+  }
+  return map;
+}
+
+/**
+ * The issue body: what the release says, and what our files contain. It reports
+ * those two facts and stops — it never asserts that a model gets something
+ * wrong, and it never proposes an edit.
+ */
+export function issueBody({ repo, tag, url, publishedAt, hits, runUrl }) {
+  const shown = hits.slice(0, MAX_HITS);
+  const out = [
+    issueMarker(repo, tag),
+    '',
+    `[${repo} ${tag}](${url}) was published on ${publishedAt.slice(0, 10)}. Its release notes announce a removal, rename, or deprecation whose name still appears in this repository's skill content.`,
+    '',
+    'These are string matches, not verified defects. Each one is either content to correct, or a mention that is still accurate in context — a maintainer decides which.',
+    ''
+  ];
+
+  for (const [note, noteHits] of groupBy(shown, (h) => h.note)) {
+    out.push('### Release note', '', `> ${note.replace(/\n/g, ' ')}`, '');
+    out.push('Still present in:', '');
+    for (const [path, pathHits] of groupBy(noteHits, (h) => h.path)) {
+      for (const hit of pathHits) {
+        out.push(`- \`${path}:${hit.line}\` — matches \`${hit.term}\``);
+      }
+    }
+    out.push('');
+  }
+
+  if (hits.length > shown.length) {
+    out.push(
+      `_${hits.length - shown.length} further match(es) not listed; rerun the workflow after these are triaged._`,
+      ''
+    );
+  }
+
+  out.push(
+    '### Scope',
+    '',
+    'This is a Class A report only: a release note said a name is going away, and that name is still in our files. It does not cover new features a model may not know about (Class B) or content a newer model may already get right (Class C).',
+    ''
+  );
+
+  // Class B triage blocks belong here once the gap-intake pipeline defines its
+  // schema. Until that schema exists there is nothing to conform to, and
+  // inventing one would produce output no pipeline can read.
+
+  if (runUrl) out.push(`[Workflow run](${runUrl})`, '');
+  return out.join('\n');
+}
+
+/**
+ * The watch list's YAML, in the restricted subset `.github/release-watch/watch.yml`
+ * is written in: a `watch:` key holding a list of entries, each a flat map of
+ * single-line scalars. Deliberately not a general YAML parser — this repository
+ * takes no runtime dependencies, and the file it reads is one we control.
+ */
+export function parseWatchList(source) {
+  const entries = [];
+  let inWatch = false;
+  let current = null;
+
+  for (const raw of String(source ?? '').split(/\r?\n/)) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    if (/^watch:\s*$/.test(line)) {
+      inWatch = true;
+      continue;
+    }
+    if (!inWatch) continue;
+    if (/^\S/.test(line)) break; // a new top-level key ends the list
+
+    const item = /^\s*-\s*(.*)$/.exec(line);
+    if (item) {
+      current = {};
+      entries.push(current);
+      if (item[1]) assign(current, item[1]);
+      continue;
+    }
+    if (current) assign(current, line.trim());
+  }
+
+  return entries.filter((entry) => entry.repo);
+}
+
+function assign(target, text) {
+  const match = /^([A-Za-z_][\w-]*):\s*(.*)$/.exec(text);
+  if (!match) return;
+  let value = match[2].trim();
+  if (
+    (value.startsWith("'") && value.endsWith("'")) ||
+    (value.startsWith('"') && value.endsWith('"'))
+  ) {
+    value = value.slice(1, -1);
+  }
+  if (value === 'true') target[match[1]] = true;
+  else if (value === 'false') target[match[1]] = false;
+  else target[match[1]] = value;
+}
+
+/**
+ * The releases worth looking at: published, not a draft or prerelease (a
+ * prerelease is how tippecanoe publishes per-commit test builds), newer than the
+ * watermark, oldest first so a missed week catches up in order.
+ */
+export function selectReleases(releases, watermark) {
+  const since = watermark?.published_at
+    ? Date.parse(watermark.published_at)
+    : 0;
+  return (releases ?? [])
+    .filter((r) => !r.draft && !r.prerelease && r.published_at)
+    .filter((r) => Date.parse(r.published_at) > since)
+    .sort((a, b) => Date.parse(a.published_at) - Date.parse(b.published_at));
+}

--- a/scripts/lib/release-watch.js
+++ b/scripts/lib/release-watch.js
@@ -26,8 +26,18 @@ const BREAKING_HEADING_WORDS = [
   'migration'
 ];
 
-/** Per-bullet markers that make a single note breaking wherever it sits. */
-const BREAKING_MARKERS = ['⚠', '💥', 'BREAKING CHANGE', 'BREAKING:'];
+/**
+ * Per-bullet markers that make a single note breaking wherever it sits. GL JS
+ * and the style spec use the warning emoji; planetiler prefixes the bullet with
+ * `[breaking]`. The word forms are compared lowercased.
+ */
+const BREAKING_MARKERS = [
+  '⚠',
+  '💥',
+  'breaking change',
+  'breaking:',
+  '[breaking]'
+];
 
 /**
  * Fixed phrases that make a note breaking on their own. A fixed list, not a
@@ -54,7 +64,21 @@ const REMOVAL_PHRASES = [
   'have been renamed',
   'renamed to',
   'replaced by',
-  'must switch to'
+  'must switch to',
+  // A removal verb directly before a code span is how a note names what went:
+  // "Remove `waitForCompletion`", "rename `mbgl` namespace to `mln`".
+  'remove `',
+  'removed `',
+  'removes `',
+  'rename `',
+  'renamed `',
+  'renames `',
+  'drop `',
+  'dropped `',
+  'drops `',
+  'deprecate `',
+  'deprecated `',
+  'deprecates `'
 ];
 
 /**
@@ -86,8 +110,7 @@ const GENERIC_IDENTIFIERS = new Set([
   'null',
   'true',
   'false',
-  'default',
-  'null'
+  'default'
 ]);
 
 const MIN_IDENTIFIER_LENGTH = 5;
@@ -102,7 +125,7 @@ const MIN_IDENTIFIER_LENGTH = 5;
  */
 const MIN_BARE_WORD_LENGTH = 12;
 
-/** Hits per issue. Past this the report stops being readable; the rest wait for the next run. */
+/** Hits per issue. Past this the report stops being readable; a local dry run prints them all. */
 export const MAX_HITS = 60;
 
 function headingLevel(line) {
@@ -178,9 +201,8 @@ export function splitNotes(body) {
 
 export function isBreakingNote(note) {
   if (note.inBreakingSection) return true;
-  if (BREAKING_MARKERS.some((marker) => note.text.includes(marker)))
-    return true;
   const lowered = note.text.toLowerCase();
+  if (BREAKING_MARKERS.some((marker) => lowered.includes(marker))) return true;
   return REMOVAL_PHRASES.some((phrase) => lowered.includes(phrase));
 }
 
@@ -333,7 +355,7 @@ export function issueBody({ repo, tag, url, publishedAt, hits, runUrl }) {
 
   if (hits.length > shown.length) {
     out.push(
-      `_${hits.length - shown.length} further match(es) not listed; rerun the workflow after these are triaged._`,
+      `_${hits.length - shown.length} further match(es) not listed. For the full list run \`node scripts/release-watch.js --dry-run --repo ${repo} --tag ${tag}\` locally._`,
       ''
     );
   }
@@ -356,13 +378,16 @@ export function issueBody({ repo, tag, url, publishedAt, hits, runUrl }) {
 /**
  * The watch list's YAML, in the restricted subset `.github/release-watch/watch.yml`
  * is written in: a `watch:` key holding a list of entries, each a flat map of
- * single-line scalars. Deliberately not a general YAML parser — this repository
- * takes no runtime dependencies, and the file it reads is one we control.
+ * scalars. A quoted value may continue onto following indented lines, which is
+ * how Prettier folds a long one. Deliberately not a general YAML parser — this
+ * repository takes no runtime dependencies, and the file it reads is one we
+ * control.
  */
 export function parseWatchList(source) {
   const entries = [];
   let inWatch = false;
   let current = null;
+  let lastKey = null;
 
   for (const raw of String(source ?? '').split(/\r?\n/)) {
     const line = raw.replace(/\s+$/, '');
@@ -376,31 +401,42 @@ export function parseWatchList(source) {
     if (/^\S/.test(line)) break; // a new top-level key ends the list
 
     const item = /^\s*-\s*(.*)$/.exec(line);
+    const text = item ? item[1] : line.trim();
     if (item) {
       current = {};
       entries.push(current);
-      if (item[1]) assign(current, item[1]);
-      continue;
+      lastKey = null;
     }
-    if (current) assign(current, line.trim());
+    if (!current || !text) continue;
+
+    const pair = /^([A-Za-z_][\w-]*):\s*(.*)$/.exec(text);
+    if (pair) {
+      lastKey = pair[1];
+      current[lastKey] = pair[2].trim();
+    } else if (lastKey) {
+      current[lastKey] = `${current[lastKey]} ${text}`.trim();
+    }
   }
 
-  return entries.filter((entry) => entry.repo);
+  return entries
+    .map((entry) =>
+      Object.fromEntries(
+        Object.entries(entry).map(([key, value]) => [key, scalar(value)])
+      )
+    )
+    .filter((entry) => entry.repo);
 }
 
-function assign(target, text) {
-  const match = /^([A-Za-z_][\w-]*):\s*(.*)$/.exec(text);
-  if (!match) return;
-  let value = match[2].trim();
+function scalar(value) {
   if (
     (value.startsWith("'") && value.endsWith("'")) ||
     (value.startsWith('"') && value.endsWith('"'))
   ) {
     value = value.slice(1, -1);
   }
-  if (value === 'true') target[match[1]] = true;
-  else if (value === 'false') target[match[1]] = false;
-  else target[match[1]] = value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
 }
 
 /**

--- a/scripts/release-watch.js
+++ b/scripts/release-watch.js
@@ -15,6 +15,9 @@
  *   node scripts/release-watch.js --dry-run
  *   node scripts/release-watch.js --dry-run --repo maplibre/maplibre-gl-js --tag v6.0.0
  *
+ * Exit status is 1 when any watched repository could not be read, so a
+ * scheduled run does not report a clean week it did not fully check.
+ *
  * Flags:
  *   --dry-run          print the issues that would be filed; no writes at all
  *   --repo <o/n>       limit the run to one watch-list entry
@@ -87,6 +90,34 @@ async function api(path, auth) {
   return res.json();
 }
 
+const PER_PAGE = 100;
+const MAX_PAGES = 10;
+
+/**
+ * The releases of `repo`, newest first, read page by page until one at or
+ * before the watermark shows up — so a long gap is caught up in full rather
+ * than cut off at the first page. With no watermark yet, one page is enough:
+ * the entry is new, and its first run only sets where to start.
+ */
+async function releasesSince(repo, watermark, auth) {
+  const since = watermark?.published_at
+    ? Date.parse(watermark.published_at)
+    : 0;
+  const releases = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const batch = await api(
+      `/repos/${repo}/releases?per_page=${PER_PAGE}&page=${page}`,
+      auth
+    );
+    releases.push(...batch);
+    const reachedWatermark = batch.some(
+      (r) => r.published_at && Date.parse(r.published_at) <= since
+    );
+    if (batch.length < PER_PAGE || reachedWatermark || !since) break;
+  }
+  return releases;
+}
+
 /** Every skill file the watch reads: SKILL.md, and AGENTS.md where a skill has one. */
 function loadSkillFiles(dir) {
   const files = [];
@@ -104,44 +135,44 @@ function loadSkillFiles(dir) {
 
 /**
  * Markers of issues already filed. Read from the label rather than the search
- * index: search tokenizes an HTML comment unpredictably, a label listing does not.
+ * index: search tokenizes an HTML comment unpredictably, a label listing does
+ * not. A label nobody has created yet lists as empty, not as an error.
  */
 async function existingMarkers(repo, auth) {
   const markers = new Set();
-  try {
+  for (let page = 1; page <= MAX_PAGES; page++) {
     const issues = await api(
-      `/repos/${repo}/issues?state=all&labels=release-watch&per_page=100`,
+      `/repos/${repo}/issues?state=all&labels=release-watch&per_page=${PER_PAGE}&page=${page}`,
       auth
     );
     for (const issue of issues) {
       const found = /<!-- release-watch: [^>]+ -->/.exec(issue.body ?? '');
       if (found) markers.add(found[0]);
     }
-  } catch (error) {
-    // A repo with the label not yet created answers 404 here; that just means
-    // nothing has been filed yet.
-    if (!/ 404 /.test(String(error.message))) throw error;
+    if (issues.length < PER_PAGE) break;
   }
   return markers;
 }
 
-function createIssue(repo, title, body) {
-  for (const label of LABELS) {
-    execFileSync(
-      'gh',
-      [
-        'label',
-        'create',
-        label,
-        '--repo',
-        repo,
-        '--force',
-        '--color',
-        'ededed'
-      ],
-      { stdio: 'ignore' }
-    );
+/**
+ * Creates a label only if it is missing. `gh label create --force` would also
+ * reset the color and description of a label a maintainer has since adjusted.
+ */
+async function ensureLabel(repo, label, auth) {
+  try {
+    await api(`/repos/${repo}/labels/${encodeURIComponent(label)}`, auth);
+    return;
+  } catch (error) {
+    if (!/ 404 /.test(String(error.message))) throw error;
   }
+  execFileSync(
+    'gh',
+    ['label', 'create', label, '--repo', repo, '--color', 'ededed'],
+    { stdio: 'inherit' }
+  );
+}
+
+function createIssue(repo, title, body) {
   execFileSync(
     'gh',
     [
@@ -176,6 +207,7 @@ const skillFiles = loadSkillFiles(args.skillsDir);
 const filed = args.dryRun ? new Set() : await existingMarkers(selfRepo, auth);
 
 const summary = [];
+const unreadable = [];
 let issuesFiled = 0;
 
 for (const entry of watchList) {
@@ -187,26 +219,31 @@ for (const entry of watchList) {
     continue;
   }
 
-  let releases;
-  try {
-    releases = await api(`/repos/${entry.repo}/releases?per_page=50`, auth);
-  } catch (error) {
-    summary.push(`- ${entry.repo}: could not be read (${error.message})`);
-    continue;
-  }
+  const watermark = args.since
+    ? { published_at: args.since }
+    : state[entry.repo];
 
   let candidates;
-  if (args.tag) {
-    candidates = releases.filter((r) => r.tag_name === args.tag);
-    if (candidates.length === 0) {
-      summary.push(`- ${entry.repo}: no release tagged ${args.tag}`);
-      continue;
+  try {
+    if (args.tag) {
+      candidates = [
+        await api(
+          `/repos/${entry.repo}/releases/tags/${encodeURIComponent(args.tag)}`,
+          auth
+        )
+      ];
+    } else {
+      candidates = selectReleases(
+        await releasesSince(entry.repo, watermark, auth),
+        watermark
+      );
     }
-  } else {
-    const watermark = args.since
-      ? { published_at: args.since }
-      : state[entry.repo];
-    candidates = selectReleases(releases, watermark);
+  } catch (error) {
+    // Nothing advances for this repo: the next run reads the same releases
+    // again. The run fails at the end so the week does not pass for clean.
+    summary.push(`- ${entry.repo}: could not be read (${error.message})`);
+    unreadable.push(entry.repo);
+    continue;
   }
 
   if (candidates.length === 0) {
@@ -246,6 +283,7 @@ for (const entry of watchList) {
       console.log(`\n=== would file: ${title}\n`);
       console.log(body);
     } else {
+      for (const label of LABELS) await ensureLabel(selfRepo, label, auth);
       createIssue(selfRepo, title, body);
       filed.add(marker);
       issuesFiled++;
@@ -274,3 +312,7 @@ if (process.env.GITHUB_STEP_SUMMARY) {
   writeFileSync(process.env.GITHUB_STEP_SUMMARY, report, { flag: 'a' });
 }
 if (!args.dryRun) console.log(`Issues filed: ${issuesFiled}`);
+if (unreadable.length > 0) {
+  console.error(`Could not read releases for: ${unreadable.join(', ')}`);
+  process.exit(1);
+}

--- a/scripts/release-watch.js
+++ b/scripts/release-watch.js
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Release watch: flags skill content an upstream release just contradicted.
+ *
+ * Reads the watch list in `.github/release-watch/watch.yml`, fetches each repo's
+ * releases newer than the watermark in `.github/release-watch/state.json`, and
+ * for every release whose notes announce a removal, rename, or deprecation,
+ * reports the skill lines that still carry the affected name. One issue per
+ * release with hits, labeled `release-watch` and `needs-triage`.
+ *
+ * Hard limits, by design: it never opens a pull request, never edits a skill
+ * file, and never closes an issue. The parsing and matching rules live in
+ * `scripts/lib/release-watch.js`.
+ *
+ *   node scripts/release-watch.js --dry-run
+ *   node scripts/release-watch.js --dry-run --repo maplibre/maplibre-gl-js --tag v6.0.0
+ *
+ * Flags:
+ *   --dry-run          print the issues that would be filed; no writes at all
+ *   --repo <o/n>       limit the run to one watch-list entry
+ *   --tag <tag>        examine exactly this release, ignoring the watermark
+ *   --since <iso8601>  override the watermark for this run
+ *   --skills-dir <d>   read skills from another checkout (used by the smoke test)
+ *   --watch <file>     watch list path
+ *   --state <file>     watermark path
+ *
+ * Env: GH_TOKEN or GITHUB_TOKEN; falls back to `gh auth token` locally.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  parseWatchList,
+  selectReleases,
+  findHits,
+  issueBody,
+  issueMarker,
+  issueTitle
+} from './lib/release-watch.js';
+
+const WATCH_DEFAULT = '.github/release-watch/watch.yml';
+const STATE_DEFAULT = '.github/release-watch/state.json';
+const LABELS = ['release-watch', 'needs-triage'];
+
+function parseArgs(argv) {
+  const args = { dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') args.dryRun = true;
+    else if (arg === '--repo') args.repo = argv[++i];
+    else if (arg === '--tag') args.tag = argv[++i];
+    else if (arg === '--since') args.since = argv[++i];
+    else if (arg === '--skills-dir') args.skillsDir = argv[++i];
+    else if (arg === '--watch') args.watch = argv[++i];
+    else if (arg === '--state') args.state = argv[++i];
+    else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(1);
+    }
+  }
+  args.watch ??= WATCH_DEFAULT;
+  args.state ??= STATE_DEFAULT;
+  args.skillsDir ??= 'skills';
+  return args;
+}
+
+function token() {
+  const fromEnv = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    return execFileSync('gh', ['auth', 'token'], { encoding: 'utf8' }).trim();
+  } catch {
+    console.error('No GH_TOKEN or GITHUB_TOKEN, and `gh auth token` failed.');
+    process.exit(1);
+  }
+}
+
+async function api(path, auth) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${auth}`,
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+  if (!res.ok) throw new Error(`GitHub API ${res.status} for ${path}`);
+  return res.json();
+}
+
+/** Every skill file the watch reads: SKILL.md, and AGENTS.md where a skill has one. */
+function loadSkillFiles(dir) {
+  const files = [];
+  for (const name of readdirSync(dir, { withFileTypes: true })) {
+    if (!name.isDirectory()) continue;
+    for (const file of ['SKILL.md', 'AGENTS.md']) {
+      const path = join(dir, name.name, file);
+      if (existsSync(path)) {
+        files.push({ path, content: readFileSync(path, 'utf8') });
+      }
+    }
+  }
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * Markers of issues already filed. Read from the label rather than the search
+ * index: search tokenizes an HTML comment unpredictably, a label listing does not.
+ */
+async function existingMarkers(repo, auth) {
+  const markers = new Set();
+  try {
+    const issues = await api(
+      `/repos/${repo}/issues?state=all&labels=release-watch&per_page=100`,
+      auth
+    );
+    for (const issue of issues) {
+      const found = /<!-- release-watch: [^>]+ -->/.exec(issue.body ?? '');
+      if (found) markers.add(found[0]);
+    }
+  } catch (error) {
+    // A repo with the label not yet created answers 404 here; that just means
+    // nothing has been filed yet.
+    if (!/ 404 /.test(String(error.message))) throw error;
+  }
+  return markers;
+}
+
+function createIssue(repo, title, body) {
+  for (const label of LABELS) {
+    execFileSync(
+      'gh',
+      [
+        'label',
+        'create',
+        label,
+        '--repo',
+        repo,
+        '--force',
+        '--color',
+        'ededed'
+      ],
+      { stdio: 'ignore' }
+    );
+  }
+  execFileSync(
+    'gh',
+    [
+      'issue',
+      'create',
+      '--repo',
+      repo,
+      '--title',
+      title,
+      '--body',
+      body,
+      '--label',
+      LABELS.join(',')
+    ],
+    { stdio: 'inherit' }
+  );
+}
+
+const args = parseArgs(process.argv.slice(2));
+const auth = token();
+const selfRepo =
+  process.env.GITHUB_REPOSITORY ?? 'maplibre/maplibre-agent-skills';
+const runUrl = process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_SERVER_URL}/${selfRepo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+  : '';
+
+const watchList = parseWatchList(readFileSync(args.watch, 'utf8'));
+const state = existsSync(args.state)
+  ? JSON.parse(readFileSync(args.state, 'utf8'))
+  : {};
+const skillFiles = loadSkillFiles(args.skillsDir);
+const filed = args.dryRun ? new Set() : await existingMarkers(selfRepo, auth);
+
+const summary = [];
+let issuesFiled = 0;
+
+for (const entry of watchList) {
+  if (args.repo && entry.repo !== args.repo) continue;
+  if (entry.enabled === false) {
+    summary.push(
+      `- ${entry.repo}: skipped — ${entry.note ?? 'disabled in the watch list'}`
+    );
+    continue;
+  }
+
+  let releases;
+  try {
+    releases = await api(`/repos/${entry.repo}/releases?per_page=50`, auth);
+  } catch (error) {
+    summary.push(`- ${entry.repo}: could not be read (${error.message})`);
+    continue;
+  }
+
+  let candidates;
+  if (args.tag) {
+    candidates = releases.filter((r) => r.tag_name === args.tag);
+    if (candidates.length === 0) {
+      summary.push(`- ${entry.repo}: no release tagged ${args.tag}`);
+      continue;
+    }
+  } else {
+    const watermark = args.since
+      ? { published_at: args.since }
+      : state[entry.repo];
+    candidates = selectReleases(releases, watermark);
+  }
+
+  if (candidates.length === 0) {
+    summary.push(`- ${entry.repo}: no new releases`);
+    continue;
+  }
+
+  for (const release of candidates) {
+    const hits = findHits(release.body ?? '', skillFiles);
+    if (hits.length === 0) {
+      // A release with no hits files nothing. An issue per release regardless
+      // would bury the ones that matter under weekly noise; the run summary is
+      // the record that it was read.
+      summary.push(`- ${entry.repo} ${release.tag_name}: read, no hits`);
+      continue;
+    }
+
+    const marker = issueMarker(entry.repo, release.tag_name);
+    if (filed.has(marker)) {
+      summary.push(
+        `- ${entry.repo} ${release.tag_name}: ${hits.length} hit(s), issue already filed`
+      );
+      continue;
+    }
+
+    const title = issueTitle(entry.repo, release.tag_name);
+    const body = issueBody({
+      repo: entry.repo,
+      tag: release.tag_name,
+      url: release.html_url,
+      publishedAt: release.published_at,
+      hits,
+      runUrl
+    });
+
+    if (args.dryRun) {
+      console.log(`\n=== would file: ${title}\n`);
+      console.log(body);
+    } else {
+      createIssue(selfRepo, title, body);
+      filed.add(marker);
+      issuesFiled++;
+    }
+    summary.push(`- ${entry.repo} ${release.tag_name}: ${hits.length} hit(s)`);
+  }
+
+  // Watermark advances past every release read, hits or not, so a rerun is
+  // idempotent and a missed week catches up instead of skipping.
+  if (!args.tag) {
+    const newest = candidates[candidates.length - 1];
+    state[entry.repo] = {
+      tag: newest.tag_name,
+      published_at: newest.published_at
+    };
+  }
+}
+
+if (!args.dryRun && !args.tag) {
+  writeFileSync(args.state, JSON.stringify(state, null, 2) + '\n');
+}
+
+const report = ['## Release watch', '', ...summary, ''].join('\n');
+console.log('\n' + report);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  writeFileSync(process.env.GITHUB_STEP_SUMMARY, report, { flag: 'a' });
+}
+if (!args.dryRun) console.log(`Issues filed: ${issuesFiled}`);

--- a/scripts/release-watch.test.js
+++ b/scripts/release-watch.test.js
@@ -75,6 +75,34 @@ describe('breakingNotes', () => {
     assert.equal(notes.length, 1);
   });
 
+  // planetiler v0.9.0 marks its breaking bullets this way, under an ordinary
+  // "Bug Fixes and Improvements" heading.
+  it('picks up a [breaking]-prefixed bullet', () => {
+    const notes = breakingNotes(
+      '### Bug Fixes and Improvements\n\n  * [breaking] fix: typo in `water_lines_labels` for shortbread tiles spec by @CommanderStorm in https://example.invalid/1215'
+    );
+    assert.equal(notes.length, 1);
+    assert.deepEqual(
+      extractTerms(notes[0].text).map((t) => t.value),
+      ['water_lines_labels']
+    );
+  });
+
+  // MapLibre Native ios-v6.29.0 names what went with a bare verb right before
+  // the code span, with no "has been" to match on. A verb that is not directly
+  // before the span ("never removed from the image manager") is not enough.
+  it('picks up a removal verb directly before a code span', () => {
+    const body = [
+      '- core: rename `mbgl` namespace to `mln` ([#4487](https://example.invalid/4487)).',
+      '- Removed `waitForCompletion`, the second parameter of `GeoJSONSource.setData`',
+      '- Fix a leak: images of a replaced sprite were never removed from the image manager'
+    ].join('\n');
+    const notes = breakingNotes(body);
+    assert.equal(notes.length, 2);
+    assert.match(notes[0].text, /mbgl/);
+    assert.match(notes[1].text, /waitForCompletion/);
+  });
+
   it('leaves ordinary notes alone', () => {
     assert.deepEqual(
       breakingNotes('### Added\n\n- Add `--tile-format=mlt`'),
@@ -245,6 +273,28 @@ describe('issueBody', () => {
   it('says the matches are unverified, not defects', () => {
     assert.match(body, /string matches, not verified defects/);
   });
+
+  it('points an overflowing report at the local dry run, not a rerun', () => {
+    const many = Array.from({ length: 70 }, (_, i) => ({
+      note: 'n',
+      heading: '',
+      term: 't',
+      kind: 'identifier',
+      path: 'skills/x/SKILL.md',
+      line: i + 1,
+      text: ''
+    }));
+    const long = issueBody({
+      repo: 'maplibre/martin',
+      tag: 'martin-v1.14.0',
+      url: 'https://example.invalid',
+      publishedAt: '2026-08-18T14:06:17Z',
+      hits: many,
+      runUrl: ''
+    });
+    assert.match(long, /10 further match\(es\) not listed/);
+    assert.match(long, /--repo maplibre\/martin --tag martin-v1\.14\.0/);
+  });
 });
 
 describe('parseWatchList', () => {
@@ -266,6 +316,21 @@ describe('parseWatchList', () => {
     assert.equal(entries[0].why, 'Martin endpoints and flags.');
     assert.equal(entries[1].enabled, false);
     assert.equal(entries[1].note, 'publishes no releases');
+  });
+
+  it('reads a quoted value Prettier folded onto several lines', () => {
+    const folded = [
+      'watch:',
+      '  - repo: maplibre/martin',
+      '    why:',
+      "      'Martin endpoints",
+      "      and flags.'",
+      '    enabled: false',
+      ''
+    ].join('\n');
+    const [entry] = parseWatchList(folded);
+    assert.equal(entry.why, 'Martin endpoints and flags.');
+    assert.equal(entry.enabled, false);
   });
 
   it('ignores an entry with no repo', () => {

--- a/scripts/release-watch.test.js
+++ b/scripts/release-watch.test.js
@@ -1,0 +1,323 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  breakingNotes,
+  extractTerms,
+  findHits,
+  issueBody,
+  issueMarker,
+  lineMatches,
+  parseWatchList,
+  selectReleases,
+  splitNotes
+} from './lib/release-watch.js';
+
+// Trimmed from the real MapLibre GL JS v6.0.0 release body. Note the shape that
+// matters: the breaking items are warning-marked bullets under a "Features and
+// improvements" heading, not under a "Breaking changes" one.
+const GL_JS_V6 = `The following incorporates all the pre-releases for version 6 changes.
+
+### ✨ Features and improvements
+
+- ⚠️ Switch to an ESM-only distribution (\`maplibre-gl.mjs\`). The UMD bundles (\`maplibre-gl.js\`, \`maplibre-gl-csp.js\`) are no longer published. Consumers using \`import maplibregl from 'maplibre-gl'\` must switch to \`import * as maplibregl from 'maplibre-gl'\` or named imports.
+- Add \`Map.setMissingStyleImageResolver\` for resolving missing style images ([#7850](https://example.invalid))
+
+### 🐞 Bug fixes
+
+- Fix camera jump in flyTo when minZoom is set
+`;
+
+const MARTIN_STYLE = `### Breaking
+
+- The \`--watch\` flag was removed; use \`--auto-bounds\` instead.
+
+### Added
+
+- e2e local geoparquet wiring via \`duckdb\`
+`;
+
+describe('splitNotes', () => {
+  it('keeps the heading each note sat under', () => {
+    const notes = splitNotes(GL_JS_V6);
+    assert.equal(notes.at(-1).heading, '🐞 Bug fixes');
+    assert.ok(notes[0].heading.includes('Features'));
+  });
+
+  it('folds a wrapped bullet back into one note', () => {
+    const notes = splitNotes('- first line\n  continued here\n\n- second');
+    assert.equal(notes.length, 2);
+    assert.equal(notes[0].text, 'first line continued here');
+  });
+
+  it('marks notes inside a breaking section', () => {
+    const notes = splitNotes(MARTIN_STYLE);
+    assert.equal(notes[0].inBreakingSection, true);
+    assert.equal(notes[1].inBreakingSection, false);
+  });
+});
+
+describe('breakingNotes', () => {
+  it('picks up a warning-marked bullet outside any breaking heading', () => {
+    const notes = breakingNotes(GL_JS_V6);
+    assert.equal(notes.length, 1);
+    assert.match(notes[0].text, /ESM-only distribution/);
+  });
+
+  it('picks up every bullet under a breaking heading', () => {
+    const notes = breakingNotes(MARTIN_STYLE);
+    assert.equal(notes.length, 1);
+    assert.match(notes[0].text, /--watch/);
+  });
+
+  it('picks up a removal phrase with no heading or marker to help', () => {
+    const notes = breakingNotes('- The `--drop-densest` flag is deprecated.');
+    assert.equal(notes.length, 1);
+  });
+
+  it('leaves ordinary notes alone', () => {
+    assert.deepEqual(
+      breakingNotes('### Added\n\n- Add `--tile-format=mlt`'),
+      []
+    );
+  });
+});
+
+describe('extractTerms', () => {
+  it('reads a code span with whitespace as a verbatim snippet', () => {
+    const terms = extractTerms(
+      "use `import maplibregl from 'maplibre-gl'` now"
+    );
+    assert.deepEqual(terms, [
+      { value: "import maplibregl from 'maplibre-gl'", kind: 'phrase' }
+    ]);
+  });
+
+  it('reads a whitespace-free span as an identifier', () => {
+    const values = extractTerms(
+      'drop `maplibre-gl.js` and `maplibre-gl.mjs`'
+    ).map((t) => t.value);
+    assert.deepEqual(values, ['maplibre-gl.js', 'maplibre-gl.mjs']);
+  });
+
+  it('ignores prose outside code spans', () => {
+    assert.deepEqual(extractTerms('the UMD bundle is no longer published'), []);
+  });
+
+  it('drops short bare words that only give a rename its context', () => {
+    const values = extractTerms(
+      '`Map` composes a `Camera`; `map.transform` was removed and `MapDataEvent` is gone'
+    ).map((t) => t.value);
+    assert.deepEqual(values, ['map.transform', 'MapDataEvent']);
+  });
+
+  it('drops names every skill mentions, and version numbers', () => {
+    assert.deepEqual(extractTerms('`maplibre-gl` at `v6.0.0`'), []);
+  });
+});
+
+describe('lineMatches', () => {
+  const term = { value: 'maplibre-gl.js', kind: 'identifier' };
+
+  it('matches an identifier inside a URL path', () => {
+    assert.equal(
+      lineMatches(
+        "src='https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js'",
+        term
+      ),
+      true
+    );
+  });
+
+  it('will not match an identifier glued to a longer word', () => {
+    assert.equal(lineMatches('see xmaplibre-gl.jsx for details', term), false);
+  });
+
+  it('matches a snippet only verbatim', () => {
+    const phrase = {
+      value: "import maplibregl from 'maplibre-gl'",
+      kind: 'phrase'
+    };
+    assert.equal(
+      lineMatches("import maplibregl from 'maplibre-gl';", phrase),
+      true
+    );
+    assert.equal(
+      lineMatches("import * as maplibregl from 'maplibre-gl';", phrase),
+      false
+    );
+  });
+});
+
+describe('findHits', () => {
+  // The pre-#59 content of the two skills the v6 UMD removal contradicted.
+  const preFix = [
+    {
+      path: 'skills/maplibre-mapbox-migration/SKILL.md',
+      content: [
+        '# Migration',
+        '',
+        '- Script: `https://api.mapbox.com/mapbox-gl-js/v2.9.0/mapbox-gl.js` -> `https://unpkg.com/maplibre-gl@5.0.0/dist/maplibre-gl.js`'
+      ].join('\n')
+    },
+    {
+      path: 'skills/maplibre-pmtiles-patterns/SKILL.md',
+      content: [
+        "import maplibregl from 'maplibre-gl';",
+        'protocol.add();'
+      ].join('\n')
+    }
+  ];
+
+  it('flags the pre-fix CDN bundle and default import', () => {
+    const hits = findHits(GL_JS_V6, preFix);
+    assert.deepEqual(
+      hits.map((h) => `${h.path}:${h.line}`),
+      [
+        'skills/maplibre-mapbox-migration/SKILL.md:3',
+        'skills/maplibre-pmtiles-patterns/SKILL.md:1'
+      ]
+    );
+  });
+
+  it('drops the removed form once the content is corrected', () => {
+    const fixed = [
+      {
+        path: 'skills/maplibre-pmtiles-patterns/SKILL.md',
+        content: "import * as maplibregl from 'maplibre-gl';"
+      }
+    ];
+    const terms = findHits(GL_JS_V6, fixed).map((h) => h.term);
+    assert.ok(!terms.includes("import maplibregl from 'maplibre-gl'"));
+  });
+
+  // A known and accepted false positive: a note that quotes both the removed
+  // form and its replacement matches the replacement too, because nothing in the
+  // prose tells the two apart mechanically. One line for a maintainer to
+  // dismiss, which is why the issue says these are matches and not defects.
+  it('still matches a replacement the note quoted', () => {
+    const fixed = [
+      {
+        path: 'skills/maplibre-pmtiles-patterns/SKILL.md',
+        content: "import * as maplibregl from 'maplibre-gl';"
+      }
+    ];
+    assert.deepEqual(
+      findHits(GL_JS_V6, fixed).map((h) => h.term),
+      ["import * as maplibregl from 'maplibre-gl'"]
+    );
+  });
+
+  it('ignores a release with nothing breaking in it', () => {
+    assert.deepEqual(
+      findHits('### Added\n\n- Add `maplibre-gl.js` docs', preFix),
+      []
+    );
+  });
+});
+
+describe('issueBody', () => {
+  const body = issueBody({
+    repo: 'maplibre/maplibre-gl-js',
+    tag: 'v6.0.0',
+    url: 'https://example.invalid/v6.0.0',
+    publishedAt: '2026-07-22T10:00:00Z',
+    hits: findHits(GL_JS_V6, [
+      {
+        path: 'skills/maplibre-mapbox-migration/SKILL.md',
+        content: 'see dist/maplibre-gl.js'
+      }
+    ]),
+    runUrl: 'https://example.invalid/run/1'
+  });
+
+  it('leads with the marker that makes a rerun idempotent', () => {
+    assert.ok(
+      body.startsWith(issueMarker('maplibre/maplibre-gl-js', 'v6.0.0'))
+    );
+  });
+
+  it('cites the hit as file:line beside the release note', () => {
+    assert.match(body, /`skills\/maplibre-mapbox-migration\/SKILL\.md:1`/);
+    assert.match(body, /ESM-only distribution/);
+  });
+
+  it('says the matches are unverified, not defects', () => {
+    assert.match(body, /string matches, not verified defects/);
+  });
+});
+
+describe('parseWatchList', () => {
+  const source = [
+    '# a comment',
+    'watch:',
+    '  - repo: maplibre/martin',
+    "    why: 'Martin endpoints and flags.'",
+    '  - repo: protomaps/PMTiles',
+    '    enabled: false',
+    "    note: 'publishes no releases'",
+    ''
+  ].join('\n');
+
+  it('reads repo, prose, and the enabled flag', () => {
+    const entries = parseWatchList(source);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].repo, 'maplibre/martin');
+    assert.equal(entries[0].why, 'Martin endpoints and flags.');
+    assert.equal(entries[1].enabled, false);
+    assert.equal(entries[1].note, 'publishes no releases');
+  });
+
+  it('ignores an entry with no repo', () => {
+    assert.deepEqual(parseWatchList('watch:\n  - why: nothing\n'), []);
+  });
+
+  it('reads the committed watch list, and every entry says why', () => {
+    const entries = parseWatchList(
+      readFileSync('.github/release-watch/watch.yml', 'utf8')
+    );
+    assert.ok(entries.length >= 8);
+    assert.ok(entries.every((entry) => entry.repo.includes('/')));
+    assert.ok(entries.every((entry) => entry.why));
+  });
+});
+
+describe('selectReleases', () => {
+  const releases = [
+    { tag_name: 'v2', published_at: '2026-02-01T00:00:00Z' },
+    { tag_name: 'v1', published_at: '2026-01-01T00:00:00Z' },
+    {
+      tag_name: 'test-abc',
+      published_at: '2026-03-01T00:00:00Z',
+      prerelease: true
+    },
+    { tag_name: 'draft', published_at: '2026-03-01T00:00:00Z', draft: true }
+  ];
+
+  it('returns everything newer than the watermark, oldest first', () => {
+    const picked = selectReleases(releases, {
+      published_at: '2025-12-01T00:00:00Z'
+    });
+    assert.deepEqual(
+      picked.map((r) => r.tag_name),
+      ['v1', 'v2']
+    );
+  });
+
+  it('skips prereleases and drafts', () => {
+    const tags = selectReleases(releases, null).map((r) => r.tag_name);
+    assert.ok(!tags.includes('test-abc'));
+    assert.ok(!tags.includes('draft'));
+  });
+
+  it('catches up across a missed week rather than skipping', () => {
+    assert.equal(selectReleases(releases, null).length, 2);
+  });
+
+  it('returns nothing when the watermark is current', () => {
+    assert.deepEqual(
+      selectReleases(releases, { published_at: '2026-02-01T00:00:00Z' }),
+      []
+    );
+  });
+});


### PR DESCRIPTION
## What this changes

Adds the release watch from #71, Class A only.

Closes #71

- `.github/workflows/release-watch.yml`: weekly (Sundays after the drift check) plus `workflow_dispatch` with `repo` / `tag` / `dry-run`.
- `.github/release-watch/watch.yml`: the watch list, each repo with the skills that depend on it.
- `.github/release-watch/state.json`: the watermark.
- `scripts/release-watch.js` + `scripts/lib/release-watch.js`: plain node, no new dependencies, 26 tests.
- CONTRIBUTING.md: a "Release watch" section with the matching rules and the smoke command.

It reads each new release, takes the backticked names out of removal/rename/deprecation notes, greps `skills/*/SKILL.md`, and files one issue per release with hits. `GITHUB_TOKEN` only, no model calls. Never opens a PR, edits a skill, or closes an issue.

Smoke test from the issue: against the pre-#59 content it flags `maplibre-mapbox-migration/SKILL.md:58`, `:64` and `maplibre-pmtiles-patterns/SKILL.md:53`, the lines #59 corrected. Against current content, nothing. Command in CONTRIBUTING.

Deviations from the issue text:

- `protomaps/PMTiles` is listed but disabled: no GitHub Releases, no tags.
- No Class B emitter until #65 settles a schema. Extension point marked.
- Watermark is `published_at`, not tag order (martin / native / tile-spec interleave tags).

Open questions, each a small follow-up if wanted:

- A per-skill opt-out, so `maplibre-v6-migration` stops matching the v6 release it documents (~30 of the 43 v6 hits).
- Labels created at runtime (current) or by hand.
- An unreadable repo fails the run weekly until fixed or disabled.

## Changelog

Bump: patch
Category: Internal
Entry: Release watch: a weekly check that files an issue when an upstream release removes, renames, or deprecates something a skill still mentions (#71)

## Checks

- [x] `npm run check` passes, plus `actionlint` and `node --test scripts/` (96/96)
- [x] Evals run, or `status: provisional` set with the gap cited above — n/a, no skill content touched
- [x] Claims are traceable to a primary source: GitHub Releases API for every date and tag; `maplibre-gl-js#8168` and #59 for the v6 timeline; each `why` line in `watch.yml` grepped against its skill. Not exercised: the scheduled run, the real `gh issue create`, and the watermark push (needs Actions write permissions, like `eval.yml`'s publish job).

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

Assisted by Claude Opus 4.6 (parser, workflow, tests, CONTRIBUTING draft; the issue text was the prompt) and Claude Fable 5 (review against 44 live release bodies: two parser false negatives, one label-clobbering `--force`).
