### PR TITLE
docs: budget skills in tokens, and record the PMTiles container probe as no gap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,8 @@ Use this skill when:
 - Lists without context or prioritization
 - Vague guidance ("might want to", "could consider")
 
+**Budget a skill in tokens, not kilobytes.** A skill's cost to the consumer is what it takes out of the model's context window every time it loads, and a diff's byte count understates that: English prose runs roughly 3.5–4 characters per token, so a 24KB `SKILL.md` is on the order of 6K tokens before the user's own question, code, or tool output is added. That is comfortable in a hosted model's window and not comfortable everywhere: Ollama, for instance, picks its default context length from available VRAM (4K, 32K, or 256K; `OLLAMA_CONTEXT_LENGTH` overrides it), and when a conversation does not fit it silently drops the oldest messages to make room, keeping the system prompt, and logs that at debug level. A 6K-token skill in a 4K window leaves nothing for the question. This is a second reason to cut content the model already gets right: every section that does not change an answer is spending someone's window.
+
 **Reference:** Include links to primary sources wherever possible. See [Attribution and References](#attribution-and-references) for a curated list.
 
 ### 4. Process skills

--- a/evals/results/maplibre-pmtiles-patterns.md
+++ b/evals/results/maplibre-pmtiles-patterns.md
@@ -16,3 +16,5 @@ Baseline run: 2026-07-03. With-skill run: re-verified 2026-07-04 after two fixes
 **Result: baseline 4 FAIL + 1 correct negative / with-skill 6/6 PASS — launch bar cleared.**
 
 A seventh test (raster-dem terrain with PMTiles) was dropped: it passed at baseline (the model already knows this pattern), so it wasn't testing a real gap under this repo's "target demonstrated gaps only" rule.
+
+A probe of "PMTiles is a container, not a source type" (there is no `pmtiles` type in the style spec; the source `type` is the type of the tiles inside the archive) was run at baseline on 2026-08-28 against `groq:openai/gpt-oss-120b` with the `google:gemini-2.5-flash-lite` judge, in two phrasings — one naming the question outright, one asking only for the source and layer JSON for imagery held in a `.pmtiles` file. Both PASSED: the model writes `type: 'raster'` with a `pmtiles://` URL and never invents a `pmtiles` source type. No gap, so no test and no content were added; recorded so it isn't rediscovered.


### PR DESCRIPTION
## What this changes

Two lines of docs from the #66 probes, no skill touched. CONTRIBUTING.md gets a paragraph on budgeting a skill in tokens rather than kilobytes (~24KB of prose ≈ 6K tokens; Ollama defaults its window to 4K/32K/256K by VRAM and silently drops the oldest messages when a conversation doesn't fit, keeping the system prompt). `evals/results/maplibre-pmtiles-patterns.md` records that "PMTiles is a container, not a source type" PASSES at baseline (three phrasings, 2026-08-28, Groq pin + Gemini judge), so nobody re-probes it.

- The rest of #66, probed at baseline before it closed, nothing landed: `sprite` as an array of `{id, url}` FAILS and `icon-text-fit` as the shield signal FAILS (content written and passing with-skill, parked until #68's `maplibre-sprites-icons` exists; noted on #68); `text-anchor` default and `symbol-placement`-as-expression PASS; style-spec `diff()` FAILS only once `icontains: '@maplibre/maplibre-gl-style-spec'` + `not-icontains: 'mapbox-gl-style-spec'` are asserted, because Gemini passed an answer recommending `@mapbox/mapbox-gl-style-spec` v13 and an invented `mapbox-style-diff` CLI; legacy `{stops}` functions PASS ×2 (noted on #8).
- One defect found on the way: `skills/maplibre-mapbox-migration/SKILL.md:134` says `npm install @maplibre/maplibre-style-spec`, and line 31 of its eval rubric requires that name. The package is `@maplibre/maplibre-gl-style-spec`; the other 404s on npm. The fix rewords a rubric, which invalidates that test's baseline row, so it goes in its own PR with a fresh run rather than here.

## Changelog

Bump: patch
Category: Internal
Entry: CONTRIBUTING: budget skills in tokens, not kilobytes; recorded the PMTiles container-vs-source-type probe as no gap (#66)

## Checks

- [x] `npm run check` passes
- [x] Evals run, or `status: provisional` set with the gap cited above — baseline probes only (`npm run eval:graded -- --var injectSkill=false`), nothing added that needed a with-skill run
- [x] Claims are traceable to a primary source (Ollama `envconfig/config.go` for the 4K/32K/256K default and `server/prompt.go` for the trim; style-spec `v8.json` `source.type` enum for the PMTiles probe)

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

Assisted by Claude Opus 4.6 (probe prompts and rubrics from the #66 items, eval runs, first drafts of both paragraphs) and Claude Fable 5 (source check on the Ollama claim, which corrected the first draft's "truncates the tail of the skill").
