### PR TITLE
Fix status field on `maplibre-v6-migration` SKILL.md

### DIFF
--- a/skills/maplibre-v6-migration/SKILL.md
+++ b/skills/maplibre-v6-migration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: maplibre-v6-migration
 description: Upgrading a MapLibre GL JS app from v5 to v6 — the ESM-only build, the removed default export, CommonJS require() breakage, the styleimagemissing/setMissingStyleImageResolver change, the removal of the internal map.transform, the MapDataEvent → MapSourceDataEvent/MapStyleDataEvent split, and the bundler-only setWorkerUrl() requirement. Use when a v5 app breaks after upgrading to v6, or before pinning a v6 install.
+status: verified
 ---
 
 # MapLibre GL JS v5 → v6 Migration


### PR DESCRIPTION
This skill already has eval prompt + committed results, and the canonical results doc reports with-skill 8/8 PASS (evals/prompts/maplibre-v6-migration.yaml, evals/results/maplibre-v6-migration.md)

## What this changes

Status field only

Bump: patch
Category: Changed
Entry: `maplibre-v6-migration`: Add missing status field

## Checks

- [ ] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above
- [ ] Claims are traceable to a primary source (MapLibre docs, style spec, or CHANGELOG)

## AI usage

- [x] No substantial AI-generated content
- [x] I wrote this PR description myself.
