### PR TITLE
docs(contributing): link the skill-creation best practices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,8 @@ Use this skill when:
 - Lists without context or prioritization
 - Vague guidance ("might want to", "could consider")
 
+**Budget:** Every line of a skill competes with everything else in the agent's context, so say only what changes an answer, and spend the space on gotchas and failure modes rather than general advice — see [Best practices for skill creators](https://agentskills.io/skill-creation/best-practices).
+
 **Reference:** Include links to primary sources wherever possible. See [Attribution and References](#attribution-and-references) for a curated list.
 
 ### 4. Process skills


### PR DESCRIPTION
## What this changes

Adds one sentence to CONTRIBUTING.md → "SKILL.md format" → "3. Content guidelines", directly after the **Avoid** list, carrying the context-budget point and linking the skill-creation best practices.

## Changelog

Bump: none

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above
- [x] Claims are traceable to a primary source (MapLibre docs, style spec, or CHANGELOG)

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

AI-generated by: Claude Opus 4.6 and Claude Fable 5 (Claude Code, under supervision). The sentence is their draft, written against the linked page; I checked it against the page and the two lists it sits between, and set the link text to the page title.
