### PR TITLE
chore(changelog): record #84, and rebase before the accrue push

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -51,6 +51,7 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add CHANGELOG.md
           git diff --staged --quiet || git commit -m "chore(changelog): record #${PR_NUMBER}"
+          git pull --rebase
           git push
 
   tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ Notable changes to this repo's skills and tooling. Loosely follows [Keep a Chang
 
 ## [Unreleased]
 
-<!-- bump: patch -->
+<!-- bump: minor -->
 
 ### Changed
 
+- `maplibre-terrain-patterns` replaced by `maplibre-terrain-rendering` (hillshade, color-relief, contours, 3D terrain and sky, `verified`), with its eval config split along the same seam and cross-references updated; the companion DEM-source content was withdrawn after a probe showed no gap to close ([#84](https://github.com/maplibre/maplibre-agent-skills/pull/84))
 - evals: rubrics for `maplibre-mapbox-migration` and `maplibre-pmtiles-patterns` now fail invented APIs; `maplibre-mapbox-migration` gains the Mapbox v2 → MapLibre API mapping, and both skills move to `verified` ([#85](https://github.com/maplibre/maplibre-agent-skills/pull/85))
 
 ## [0.2.0] - 2026-08-30


### PR DESCRIPTION
## What

- Records #84's changelog entry (Changed, bump minor) under `[Unreleased]`, produced by `scripts/accrue-changelog.js` from the PR's own Changelog field.
- `changelog.yml`: `git pull --rebase` before `git push` in the accrue job.

## Why

#84 and #85 were merged about 30 seconds apart. #85's accrue run pushed first, and #84's push was rejected (`main -> main (fetch first)`, run 33398031303), so its entry and its `minor` bump were dropped. Rebasing before the push lets back-to-back merges each land their entry.

## Changelog

Bump: none