### PR TITLE
chore: clear the open Dependabot and CodeQL alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7717,9 +7717,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -12246,13 +12246,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -12816,15 +12817,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/scripts/changelog-field.test.js
+++ b/scripts/changelog-field.test.js
@@ -35,6 +35,16 @@ describe('parseChangelogField', () => {
     assert.equal(result.errors.length, 0);
   });
 
+  it('strips comments that only form after a first pass', () => {
+    // Removing the inner comment leaves "<!--\nBump: major\n-->", which a
+    // single pass would then read as the Bump field.
+    const body =
+      '<!<!-- a -->--\nBump: major\n-->\nBump: patch\nCategory: Internal\nEntry: x';
+    const result = parseChangelogField(body);
+    assert.equal(result.bump, 'patch');
+    assert.equal(result.errors.length, 0);
+  });
+
   it('returns none with no entry or category required', () => {
     const body = 'Bump: none\nSome other text';
     const result = parseChangelogField(body);

--- a/scripts/lib/changelog-field.js
+++ b/scripts/lib/changelog-field.js
@@ -3,6 +3,18 @@ const VALID_CATEGORIES = ['Added', 'Changed', 'Fixed', 'Removed', 'Internal'];
 const CATEGORY_SET = new Set(VALID_CATEGORIES.map((c) => c.toLowerCase()));
 const BUMP_ORDER = { patch: 1, minor: 2, major: 3 };
 
+// Repeat until nothing changes: a single pass over "<!<!-- a -->--" leaves
+// "<!--" behind (CodeQL js/incomplete-multi-character-sanitization).
+function stripHtmlComments(text) {
+  let stripped = text;
+  let previous;
+  do {
+    previous = stripped;
+    stripped = stripped.replace(/<!--[\s\S]*?-->/g, '');
+  } while (stripped !== previous);
+  return stripped;
+}
+
 function parseLine(text, key) {
   for (const line of text.split('\n')) {
     const cleaned = line.replace(/\*\*/g, '').trim();
@@ -17,7 +29,7 @@ function parseChangelogField(body) {
     return { errors: ['PR body is empty.'] };
   }
 
-  const stripped = body.replace(/<!--[\s\S]*?-->/g, '');
+  const stripped = stripHtmlComments(body);
   const errors = [];
 
   const bumpRaw = parseLine(stripped, 'Bump');


### PR DESCRIPTION
## What this changes

Clears the repo's Security tab: the two open Dependabot alerts on `fast-uri` ([158](https://github.com/maplibre/maplibre-agent-skills/security/dependabot/158), [159](https://github.com/maplibre/maplibre-agent-skills/security/dependabot/159)) and the one open CodeQL alert, `js/incomplete-multi-character-sanitization` in `scripts/lib/changelog-field.js` ([code-scanning/2](https://github.com/maplibre/maplibre-agent-skills/security/code-scanning/2)). Those links resolve for maintainers only.

- `scripts/lib/changelog-field.js`: `parseChangelogField` removed HTML comments from the PR body with a single `replace`, which leaves a fresh `<!--` behind on an input like `<!<!-- a -->--`. The stripper now repeats until the text stops changing. That is the shape the query exempts ("Don't flag replace operations that are called repeatedly in a loop, as they can actually work correctly", `IncompleteMultiCharacterSanitizationQuery.qll`) and the fix its help text recommends. The new test in `scripts/changelog-field.test.js` was written first and failed on the old code: a body whose comment only forms after the first pass read `Bump: major` instead of `Bump: patch`.
- `package-lock.json`: `npm audit fix`, lockfile only. `fast-uri` 3.1.5 → 3.1.7 (GHSA-fph4-wmhf-6fwf and GHSA-5jgf-p345-68v8, plus GHSA-f65p-4m7j-42xc and GHSA-jqff-g426-hqxp, which `npm audit` reports and Dependabot has not filed), `qs` 6.15.2 → 6.16.0 (GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g), `side-channel` 1.1.0 → 1.1.1. All three are transitive through promptfoo. `package.json` is untouched, and `npm audit` reports no vulnerabilities after.

Both kinds of alert close on their own once this is on `main`: Dependabot when the dependency graph refreshes, CodeQL on its next analysis of `main`. CodeQL's analysis of this PR is the check that the loop satisfies the query. The script tests ran locally on Node 20 (`npm test`, 97 passing); `check.yml` does not run them.

## Changelog

Bump: patch
Category: Internal
Entry: `scripts/lib/changelog-field.js`: HTML comments in a PR body are stripped until none remain, closing the open CodeQL alert; `package-lock.json` moved past the `fast-uri` and `qs` advisories

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above (no skill or eval is touched)
- [x] Claims are traceable to a primary source (MapLibre docs, style spec, or CHANGELOG)

Sources for the claims above: the CodeQL query, its library, and its help text in `github/codeql` (`javascript/ql/src/Security/CWE-116/` and `javascript/ql/lib/semmle/javascript/security/`), and the GHSA advisories as listed by `npm audit` and the Dependabot alerts. Nothing under `package.json` or `evals/prompts/lib/` is touched; the lockfile diff is the three version moves above.

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

AI-generated by: Claude Fable 5.1 (Claude Code, under supervision). The fixpoint loop, the regression test, and the `npm audit fix` run are its work. I read the CodeQL query and its help text myself to confirm the loop is the shape it exempts, checked the three version moves against the lockfile diff, and ran the tests and `npm run check` before this went up.
