### PR TITLE
ci(eval): bound the weekly run, classify infrastructure failures, and publish on the branch tip

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -10,6 +10,12 @@ name: Eval
 #
 # Runs in this repo's own Actions context with its secrets regardless of ref —
 # see evals/README.md → CI before dispatching against an unreviewed ref.
+#
+# Each config runs under a per-config time bound inside a run budget
+# (EVAL_CONFIG_MINUTES, EVAL_BUDGET_MINUTES below) and reports one of three
+# verdicts: pass, fail, or error. `error` means no graded verdict — a provider
+# or judge failure, a config the bound cut off, or one the budget never
+# reached — and never moves a skill's `status:` field.
 
 on:
   schedule:
@@ -36,6 +42,11 @@ permissions:
 jobs:
   eval:
     runs-on: ubuntu-latest
+    # A backstop under GitHub's 360-minute default, not the working bound: a job
+    # GitHub kills writes no outputs at all, which is how the 2026-08-30 run
+    # spent six hours and left no evidence. The per-config bound below is what
+    # should end a bad run.
+    timeout-minutes: 300
     # Checks out inputs.ref, arbitrary on dispatch, so it holds the API secrets
     # but no write token. Repo writes are in the publish job.
     permissions:
@@ -55,57 +66,29 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Select eval configs
-        id: configs
-        run: |
-          if [ -n "${{ inputs.configs }}" ]; then
-            CONFIGS="${{ inputs.configs }}"
-          else
-            # Every skill with an eval config. Globbing rather than a hardcoded list:
-            # a new skill is covered the moment its config lands.
-            CONFIGS=$(find evals/prompts -maxdepth 1 -name '*.yaml' ! -name 'TEMPLATE.yaml' | sort | xargs)
-          fi
-          if [ -z "$CONFIGS" ]; then
-            echo "No eval configs found." >&2
-            exit 1
-          fi
-          echo "configs=$CONFIGS" >> $GITHUB_OUTPUT
-          echo "Evaluating: $CONFIGS"
-
+      # Every skill with an eval config. Globbing rather than a hardcoded list:
+      # a new skill is covered the moment its config lands.
+      #
+      # One promptfoo invocation per config — never combine them. Promptfoo
+      # merges the defaultTest blocks of combined configs (last one wins),
+      # which would inject a single skill's SKILL.md into every test.
+      #
+      # The runner sets PROMPTFOO_MAX_EVAL_TIME_MS per child, so a config that
+      # overruns finalizes with ERROR rows and still writes both outputs. The
+      # two bounds live here rather than only in the script so they are visible
+      # and tunable in YAML; healthy configs took 5 to 10 minutes on 2026-08-30.
       - name: Run evals
         id: run
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           PROMPTFOO_DISABLE_TELEMETRY: '1'
-        run: |
-          if [ "${{ inputs.baseline }}" = "true" ]; then
-            BASELINE_FLAG="--var injectSkill=false"
-            NAME="baseline-$(date +%Y-%m-%d)"
-          else
-            BASELINE_FLAG=""
-            NAME="$(date +%Y-%m-%d)"
-          fi
-          echo "name=$NAME" >> $GITHUB_OUTPUT
-
-          # One promptfoo invocation per config — never combine them. Promptfoo
-          # merges the defaultTest blocks of combined configs (last one wins),
-          # which would inject a single skill's SKILL.md into every test.
-          mkdir -p evals/results
-          FAIL=0
-          : > /tmp/skill-verdicts.txt
-          for config in ${{ steps.configs.outputs.configs }}; do
-            skill=$(basename "$config" .yaml)
-            if npm run eval:graded -- \
-              --config "$config" $BASELINE_FLAG \
-              --output "evals/results/${NAME}-${skill}.csv"; then
-              echo "${skill}:pass" >> /tmp/skill-verdicts.txt
-            else
-              echo "${skill}:fail" >> /tmp/skill-verdicts.txt
-              FAIL=1
-            fi
-          done
-          exit $FAIL
+          INPUT_CONFIGS: ${{ inputs.configs }}
+          INPUT_BASELINE: ${{ inputs.baseline }}
+          EVAL_WORK_DIR: ${{ runner.temp }}/eval
+          EVAL_CONFIG_MINUTES: 30
+          EVAL_BUDGET_MINUTES: 240
+        run: node scripts/run-evals.js
 
       - name: Upload results
         if: always()
@@ -119,7 +102,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: eval-verdicts-${{ github.run_id }}
-          path: /tmp/skill-verdicts.txt
+          path: ${{ runner.temp }}/eval
           if-no-files-found: ignore
 
   # Repo writes, scheduled runs only: checks out the default branch, never a
@@ -134,7 +117,12 @@ jobs:
     env:
       name: ${{ needs.eval.outputs.name }}
     steps:
+      # The branch tip, not the trigger SHA a scheduled run checks out by
+      # default: main moves while the eval job runs, and a push from the trigger
+      # SHA is then rejected as non-fast-forward.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -151,9 +139,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: eval-verdicts-${{ github.run_id }}
-          path: /tmp
+          path: ${{ runner.temp }}/eval
 
       - name: Commit results
+        id: commit
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
@@ -161,6 +150,7 @@ jobs:
           # the scheduled run's dated CSVs are the exception, hence -f.
           git add -f evals/results/${{ env.name }}-*.csv
           git diff --staged --quiet || git commit -m "chore: eval results ${{ env.name }}"
+          git pull --rebase
           git push
 
       # Flips status: provisional -> verified on pass, status: verified -> provisional
@@ -169,15 +159,31 @@ jobs:
       # scripts/sync-skill-status.js.
       - name: Sync skill status from drift check
         id: sync
-        run: node scripts/sync-skill-status.js /tmp/skill-verdicts.txt
+        run: node scripts/sync-skill-status.js "$RUNNER_TEMP/eval/verdicts.txt"
 
       - name: Commit status changes
+        id: status_commit
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add skills/*/SKILL.md
           git diff --staged --quiet || git commit -m "chore: sync skill status from ${{ env.name }} drift check"
+          git pull --rebase
           git push
+
+      # Reads the run's own record and says what this run was, so the issue
+      # below opens with a verdict instead of a checklist. always() because the
+      # runs worth classifying are exactly the ones where a step above failed.
+      - name: Classify the run
+        id: classify
+        if: always()
+        env:
+          EVAL_RESULT: ${{ needs.eval.result }}
+          COMMIT_OUTCOME: ${{ steps.commit.outcome }}
+          SYNC_OUTCOME: ${{ steps.sync.outcome }}
+          STATUS_COMMIT_OUTCOME: ${{ steps.status_commit.outcome }}
+          SYNC_PARTIAL: ${{ steps.sync.outputs.partial }}
+        run: node scripts/eval-issue.js
 
       # A status flip is expected-by-design behavior, not a failure — this is a
       # "review this" notice, separate from the eval-drift issue below which
@@ -245,18 +251,29 @@ jobs:
 
       # This run watches for drift — a provider silently updating a model behind a
       # pinned ID. So the issue asks a question; it does not assert a cause.
+      # The classification block above the questions reports what the run did,
+      # which is not the same as why. `!= 'success'` rather than `== 'failure'`
+      # so a cancelled job — a job-level timeout — opens an issue too.
       - name: Open issue on failure
-        if: always() && needs.eval.result == 'failure'
+        if: always() && needs.eval.result != 'success'
         uses: actions/github-script@v7
+        env:
+          HEADLINE: ${{ steps.classify.outputs.headline }}
+          CLASSIFICATION: ${{ steps.classify.outputs.classification }}
         with:
           script: |
             const date = new Date().toISOString().slice(0, 10);
             const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const headline = process.env.HEADLINE || 'investigate: infra, noise, or drift?';
             github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Eval drift check failed — ${date} (investigate: infra, noise, or drift?)`,
+              title: `Eval drift check: ${headline} — ${date}`,
               body: [
+                process.env.CLASSIFICATION || '',
+                ``,
+                `---`,
+                ``,
                 `The eval drift check failed. **This is not yet a regression** — triage it before treating it as one.`,
                 ``,
                 `[Workflow run](${run})`,

--- a/evals/README.md
+++ b/evals/README.md
@@ -166,5 +166,7 @@ context with its secrets regardless of whose ref it checks out.
 harness (`evals/prompts/lib/`) as a reason to look closer — `--ignore-scripts` blocks
 a malicious lifecycle script, not a modified `eval:graded` command.
 
+**Three verdicts, and only two of them move a status.** `scripts/run-evals.js` runs one `npm run eval:graded` per config and records `pass`, `fail`, or `error` for each. `error` means the run reached no graded verdict — a provider or judge failure, a config the per-config time bound cut off, or one the run budget never reached — and `scripts/sync-skill-status.js` leaves those skills' `status:` fields exactly as they were, in either direction, so a rate-limited Sunday cannot demote a skill. A skill whose config produced no line at all is reported with a `::warning::` and makes the run partial. The two bounds are `EVAL_CONFIG_MINUTES` and `EVAL_BUDGET_MINUTES` on the "Run evals" step in `eval.yml`; the run's verdict artifact holds `verdicts.txt`, a `summary.json` with per-config counts, error signatures, and token usage, and one JSON sidecar per config, which is where the error text behind an ERROR row survives — the CSV's ERROR rows carry an empty output and an empty grader reason.
+
 `npm run lint:model-pins` fails on any provider id that drifts from the [Setup](#setup)
 pins (the generator in `providers.yaml`, the judge in the `eval:graded` script).

--- a/scripts/eval-issue.js
+++ b/scripts/eval-issue.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Turns the weekly run's own record into the two things the drift issue needs:
+ * a `headline` for its title, and a `classification` block for the top of its
+ * body. The triage checklist below that block stays as written — this only says
+ * what happened first, so the reader is not asked to rediscover it from the log.
+ *
+ * A missing summary.json is itself the answer: the run was cancelled before any
+ * config finished, which is exactly the 2026-08-30 failure.
+ *
+ *   node scripts/eval-issue.js [path/to/summary.json]
+ *
+ * Env: EVAL_WORK_DIR or RUNNER_TEMP for the default path; EVAL_RESULT (the eval
+ * job's result), COMMIT_OUTCOME, SYNC_OUTCOME, STATUS_COMMIT_OUTCOME, and
+ * SYNC_PARTIAL for the publish steps.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { classificationBlock, headlineFor } from './lib/eval-verdicts.js';
+import { setOutputs } from './lib/github-output.js';
+
+const workDir =
+  process.env.EVAL_WORK_DIR ??
+  (process.env.RUNNER_TEMP ? join(process.env.RUNNER_TEMP, 'eval') : 'eval');
+const summaryPath = process.argv[2] ?? join(workDir, 'summary.json');
+
+let summary = null;
+try {
+  summary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+} catch {
+  console.log(`No run summary at ${summaryPath}.`);
+}
+
+const evalResult = process.env.EVAL_RESULT ?? '';
+const publish = {
+  commit: process.env.COMMIT_OUTCOME ?? '',
+  sync: process.env.SYNC_OUTCOME ?? '',
+  statusCommit: process.env.STATUS_COMMIT_OUTCOME ?? '',
+  partial: process.env.SYNC_PARTIAL === 'true'
+};
+
+const headline = headlineFor({ summary, evalResult });
+const classification = classificationBlock({ summary, evalResult, publish });
+
+console.log(classification);
+setOutputs({ headline, classification });

--- a/scripts/eval-verdicts.test.js
+++ b/scripts/eval-verdicts.test.js
@@ -1,0 +1,414 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  classificationBlock,
+  classifyEval,
+  headlineFor,
+  listEvalConfigs,
+  missingVerdicts,
+  parseVerdicts,
+  runName,
+  signatureOf,
+  skillOf
+} from './lib/eval-verdicts.js';
+
+// Shaped like a real `promptfoo eval --output x.json` file: the top level is
+// { evalId, results: <EvaluateSummary v3>, config, metadata }, and the rows sit
+// at results.results. See the note in scripts/lib/eval-verdicts.js.
+function sidecar(rows, stats = {}) {
+  return {
+    evalId: 'fixture-eval-id',
+    results: {
+      version: 3,
+      timestamp: '2026-08-30T10:24:47.000Z',
+      prompts: [],
+      results: rows,
+      stats: {
+        successes: 0,
+        failures: 0,
+        errors: 0,
+        tokenUsage: { total: 0 },
+        ...stats
+      }
+    },
+    config: {},
+    metadata: {}
+  };
+}
+
+function row(failureReason, description, error) {
+  return {
+    description,
+    failureReason,
+    success: failureReason === 0,
+    score: failureReason === 0 ? 1 : 0,
+    testIdx: 0,
+    ...(error === undefined ? {} : { error })
+  };
+}
+
+const GRADER_RATE_LIMIT =
+  'RateLimitExhaustedError: Rate limit exceeded for google:gemini-2.5-flash-lite after 4 attempts';
+const QUEUE_TIMEOUT =
+  'Request groq:openai/gpt-oss-120b[7b7ebfedd4ce]-1788103001543-7fjq3b4amns-0 timed out after 300000ms in queue';
+const MAX_DURATION = 'Evaluation exceeded max duration of 2700000ms';
+
+describe('classifyEval', () => {
+  it('calls an all-passing run a pass', () => {
+    const result = classifyEval(
+      sidecar([
+        row(0, 'explicit — asks for a raster source'),
+        row(0, 'implicit — asks how to show terrain'),
+        row(0, 'anti-pattern — asks about maxzoom'),
+        row(0, 'negative — asks about geocoding')
+      ])
+    );
+    assert.equal(result.verdict, 'pass');
+    assert.deepEqual(result.counts, { pass: 4, fail: 0, error: 0 });
+    assert.equal(result.total, 4);
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.signatures, []);
+  });
+
+  it('calls a graded assertion failure a fail', () => {
+    const result = classifyEval(
+      sidecar([row(0, 'explicit'), row(1, 'implicit'), row(0, 'negative')])
+    );
+    assert.equal(result.verdict, 'fail');
+    assert.deepEqual(result.counts, { pass: 2, fail: 1, error: 0 });
+  });
+
+  it('calls one error among passes an error', () => {
+    const result = classifyEval(
+      sidecar([
+        row(0, 'explicit'),
+        row(2, 'implicit', QUEUE_TIMEOUT),
+        row(0, 'negative')
+      ])
+    );
+    assert.equal(result.verdict, 'error');
+    assert.deepEqual(result.counts, { pass: 2, fail: 0, error: 1 });
+    assert.deepEqual(result.signatures, ['generator-queue-timeout']);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors[0].description, 'implicit');
+    assert.equal(result.errors[0].message, QUEUE_TIMEOUT);
+  });
+
+  it('lets an error outrank an assertion failure in the same run', () => {
+    const result = classifyEval(
+      sidecar([
+        row(1, 'explicit'),
+        row(2, 'implicit', GRADER_RATE_LIMIT),
+        row(0, 'negative')
+      ])
+    );
+    assert.equal(result.verdict, 'error');
+    assert.deepEqual(result.counts, { pass: 1, fail: 1, error: 1 });
+    assert.deepEqual(result.signatures, ['grader-rate-limit']);
+  });
+
+  it('reads the max-duration rows the time bound writes', () => {
+    const result = classifyEval(
+      sidecar([
+        row(0, 'explicit'),
+        row(2, 'implicit', MAX_DURATION),
+        row(2, 'anti-pattern', MAX_DURATION),
+        row(2, 'negative', MAX_DURATION)
+      ])
+    );
+    assert.equal(result.verdict, 'error');
+    assert.deepEqual(result.signatures, ['max-duration']);
+    assert.equal(result.errors.length, 3);
+  });
+
+  it('carries the token usage through when the sidecar has it', () => {
+    const result = classifyEval(
+      sidecar([row(0, 'explicit')], { tokenUsage: { total: 42000 } })
+    );
+    assert.deepEqual(result.tokenUsage, { total: 42000 });
+  });
+
+  it('throws rather than guess at an unexpected shape', () => {
+    assert.throws(() => classifyEval(null), /results/);
+    assert.throws(() => classifyEval({}), /results/);
+    assert.throws(() => classifyEval({ results: [] }), /results/);
+    assert.throws(() => classifyEval(sidecar([])), /no results/);
+    assert.throws(
+      () => classifyEval(sidecar([row(3, 'explicit')])),
+      /failureReason/
+    );
+    assert.throws(
+      () => classifyEval(sidecar([{ description: 'explicit' }])),
+      /failureReason/
+    );
+  });
+});
+
+describe('signatureOf', () => {
+  it('names the grader rate limit', () => {
+    assert.equal(signatureOf(GRADER_RATE_LIMIT), 'grader-rate-limit');
+  });
+
+  it('names the generator queue timeout', () => {
+    assert.equal(signatureOf(QUEUE_TIMEOUT), 'generator-queue-timeout');
+  });
+
+  it('names the time bound', () => {
+    assert.equal(signatureOf(MAX_DURATION), 'max-duration');
+  });
+
+  it('names a generator rate limit from a 429 or its text', () => {
+    assert.equal(
+      signatureOf('API error: 429 Too Many Requests'),
+      'generator-rate-limit'
+    );
+    assert.equal(
+      signatureOf('Rate limit exceeded, please retry'),
+      'generator-rate-limit'
+    );
+  });
+
+  it('falls back to other, and never throws on an absent message', () => {
+    assert.equal(signatureOf('ECONNRESET'), 'other');
+    assert.equal(signatureOf(undefined), 'other');
+    assert.equal(signatureOf(''), 'other');
+  });
+});
+
+describe('parseVerdicts', () => {
+  it('reads one skill per line, blank lines ignored', () => {
+    const verdicts = parseVerdicts(
+      'maplibre-cartography:pass\n\nmaplibre-fonts-glyphs:error\nmaplibre-tile-sources:fail\n'
+    );
+    assert.deepEqual(
+      [...verdicts],
+      [
+        ['maplibre-cartography', 'pass'],
+        ['maplibre-fonts-glyphs', 'error'],
+        ['maplibre-tile-sources', 'fail']
+      ]
+    );
+  });
+
+  it('is empty for empty input', () => {
+    assert.equal(parseVerdicts('').size, 0);
+    assert.equal(parseVerdicts('\n\n').size, 0);
+  });
+
+  it('rejects a malformed line rather than skipping it', () => {
+    assert.throws(() => parseVerdicts('maplibre-cartography'), /cartography/);
+    assert.throws(() => parseVerdicts('maplibre-cartography:ok'), /ok/);
+    assert.throws(() => parseVerdicts('a:pass\nb:PASS'), /PASS/);
+  });
+});
+
+describe('missingVerdicts', () => {
+  it('names every expected skill with no line of its own', () => {
+    const verdicts = parseVerdicts('a:pass\nc:error\n');
+    assert.deepEqual(missingVerdicts(verdicts, ['a', 'b', 'c', 'd']), [
+      'b',
+      'd'
+    ]);
+    assert.deepEqual(missingVerdicts(verdicts, ['a', 'c']), []);
+  });
+});
+
+describe('listEvalConfigs', () => {
+  it('sorts the yaml configs and drops the template', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'eval-configs-'));
+    mkdirSync(join(dir, 'lib'));
+    for (const name of [
+      'maplibre-tile-sources.yaml',
+      'maplibre-cartography.yaml',
+      'TEMPLATE.yaml',
+      'README.md'
+    ]) {
+      writeFileSync(join(dir, name), '');
+    }
+    assert.deepEqual(listEvalConfigs(dir), [
+      join(dir, 'maplibre-cartography.yaml'),
+      join(dir, 'maplibre-tile-sources.yaml')
+    ]);
+  });
+});
+
+describe('skillOf and runName', () => {
+  it('takes the skill name from the config filename', () => {
+    assert.equal(
+      skillOf('evals/prompts/maplibre-cartography.yaml'),
+      'maplibre-cartography'
+    );
+  });
+
+  it('prefixes a baseline run name', () => {
+    assert.equal(runName('2026-09-06', false), '2026-09-06');
+    assert.equal(runName('2026-09-06', true), 'baseline-2026-09-06');
+  });
+});
+
+const PASSING = {
+  name: '2026-09-06',
+  baseline: false,
+  planned: ['maplibre-cartography', 'maplibre-fonts-glyphs'],
+  configs: [
+    { skill: 'maplibre-cartography', verdict: 'pass', signatures: [] },
+    { skill: 'maplibre-fonts-glyphs', verdict: 'pass', signatures: [] }
+  ]
+};
+
+function withConfigs(configs) {
+  return { ...PASSING, configs };
+}
+
+describe('headlineFor', () => {
+  it('says cancelled when no summary was written at all', () => {
+    assert.equal(
+      headlineFor({ summary: null, evalResult: 'cancelled' }),
+      'cancelled before results'
+    );
+  });
+
+  it('says graded failure when only rubrics failed', () => {
+    const summary = withConfigs([
+      { skill: 'maplibre-cartography', verdict: 'fail', signatures: [] },
+      { skill: 'maplibre-fonts-glyphs', verdict: 'pass', signatures: [] }
+    ]);
+    assert.equal(
+      headlineFor({ summary, evalResult: 'failure' }),
+      'graded failure'
+    );
+  });
+
+  it('says infrastructure when only providers failed', () => {
+    const summary = withConfigs([
+      {
+        skill: 'maplibre-cartography',
+        verdict: 'error',
+        signatures: ['grader-rate-limit']
+      },
+      { skill: 'maplibre-fonts-glyphs', verdict: 'pass', signatures: [] }
+    ]);
+    assert.equal(
+      headlineFor({ summary, evalResult: 'failure' }),
+      'infrastructure'
+    );
+  });
+
+  it('says cut off when the time bound or the budget ended the run', () => {
+    const bound = withConfigs([
+      {
+        skill: 'maplibre-cartography',
+        verdict: 'error',
+        signatures: ['max-duration']
+      },
+      {
+        skill: 'maplibre-fonts-glyphs',
+        verdict: 'error',
+        signatures: ['not-run'],
+        reason: 'not-run: budget exhausted'
+      }
+    ]);
+    assert.equal(
+      headlineFor({ summary: bound, evalResult: 'failure' }),
+      'cut off by the time bound'
+    );
+  });
+
+  it('says cut off when fewer configs were recorded than planned', () => {
+    const partial = {
+      ...PASSING,
+      configs: [
+        { skill: 'maplibre-cartography', verdict: 'pass', signatures: [] }
+      ]
+    };
+    assert.equal(
+      headlineFor({ summary: partial, evalResult: 'cancelled' }),
+      'cut off by the time bound'
+    );
+  });
+
+  it('says mixed when a graded failure and an error share the run', () => {
+    const summary = withConfigs([
+      { skill: 'maplibre-cartography', verdict: 'fail', signatures: [] },
+      {
+        skill: 'maplibre-fonts-glyphs',
+        verdict: 'error',
+        signatures: ['generator-queue-timeout']
+      }
+    ]);
+    assert.equal(headlineFor({ summary, evalResult: 'failure' }), 'mixed');
+  });
+
+  it('calls an all-pass record with a non-success job infrastructure', () => {
+    assert.equal(
+      headlineFor({ summary: PASSING, evalResult: 'cancelled' }),
+      'infrastructure'
+    );
+  });
+});
+
+describe('classificationBlock', () => {
+  it('leads with the headline and tabulates every planned skill', () => {
+    const summary = withConfigs([
+      { skill: 'maplibre-cartography', verdict: 'pass', signatures: [] },
+      {
+        skill: 'maplibre-fonts-glyphs',
+        verdict: 'error',
+        signatures: ['generator-queue-timeout'],
+        tokenUsage: { total: 12000 }
+      }
+    ]);
+    const block = classificationBlock({
+      summary,
+      evalResult: 'failure',
+      publish: { commit: 'success', sync: 'success', statusCommit: 'skipped' }
+    });
+    assert.match(block, /\*\*Classification: infrastructure\.\*\*/);
+    assert.match(block, /\| maplibre-cartography \| pass \|/);
+    assert.match(
+      block,
+      /\| maplibre-fonts-glyphs \| error \| generator-queue-timeout \|/
+    );
+    assert.match(block, /2 of 2 planned configs recorded/);
+    assert.match(block, /12,000/);
+    assert.match(block, /never changes a skill's `status:`/);
+  });
+
+  it('reports a rejected push in the publish steps', () => {
+    const block = classificationBlock({
+      summary: PASSING,
+      evalResult: 'failure',
+      publish: { commit: 'failure', sync: 'skipped', statusCommit: 'skipped' }
+    });
+    assert.match(block, /Results CSVs: not committed: push rejected/);
+    assert.match(block, /Status sync: did not run/);
+  });
+
+  it('flags a partial sync', () => {
+    const block = classificationBlock({
+      summary: PASSING,
+      evalResult: 'failure',
+      publish: {
+        commit: 'success',
+        sync: 'success',
+        statusCommit: 'success',
+        partial: true
+      }
+    });
+    assert.match(block, /Status sync: ran \(partial/);
+  });
+
+  it('says plainly that nothing finished when there is no summary', () => {
+    const block = classificationBlock({
+      summary: null,
+      evalResult: 'cancelled',
+      publish: { commit: 'failure', sync: 'skipped', statusCommit: 'skipped' }
+    });
+    assert.match(block, /\*\*Classification: cancelled before results\.\*\*/);
+    assert.match(block, /No summary\.json/);
+    assert.match(block, /Results CSVs: not committed: push rejected/);
+  });
+});

--- a/scripts/eval-verdicts.test.js
+++ b/scripts/eval-verdicts.test.js
@@ -91,7 +91,7 @@ describe('classifyEval', () => {
     );
     assert.equal(result.verdict, 'error');
     assert.deepEqual(result.counts, { pass: 2, fail: 0, error: 1 });
-    assert.deepEqual(result.signatures, ['generator-queue-timeout']);
+    assert.deepEqual(result.signatures, ['queue-timeout']);
     assert.equal(result.errors.length, 1);
     assert.equal(result.errors[0].description, 'implicit');
     assert.equal(result.errors[0].message, QUEUE_TIMEOUT);
@@ -107,7 +107,7 @@ describe('classifyEval', () => {
     );
     assert.equal(result.verdict, 'error');
     assert.deepEqual(result.counts, { pass: 1, fail: 1, error: 1 });
-    assert.deepEqual(result.signatures, ['grader-rate-limit']);
+    assert.deepEqual(result.signatures, ['rate-limit-exhausted']);
   });
 
   it('reads the max-duration rows the time bound writes', () => {
@@ -149,11 +149,11 @@ describe('classifyEval', () => {
 
 describe('signatureOf', () => {
   it('names the grader rate limit', () => {
-    assert.equal(signatureOf(GRADER_RATE_LIMIT), 'grader-rate-limit');
+    assert.equal(signatureOf(GRADER_RATE_LIMIT), 'rate-limit-exhausted');
   });
 
   it('names the generator queue timeout', () => {
-    assert.equal(signatureOf(QUEUE_TIMEOUT), 'generator-queue-timeout');
+    assert.equal(signatureOf(QUEUE_TIMEOUT), 'queue-timeout');
   });
 
   it('names the time bound', () => {
@@ -161,13 +161,10 @@ describe('signatureOf', () => {
   });
 
   it('names a generator rate limit from a 429 or its text', () => {
-    assert.equal(
-      signatureOf('API error: 429 Too Many Requests'),
-      'generator-rate-limit'
-    );
+    assert.equal(signatureOf('API error: 429 Too Many Requests'), 'rate-limit');
     assert.equal(
       signatureOf('Rate limit exceeded, please retry'),
-      'generator-rate-limit'
+      'rate-limit'
     );
   });
 
@@ -287,7 +284,7 @@ describe('headlineFor', () => {
       {
         skill: 'maplibre-cartography',
         verdict: 'error',
-        signatures: ['grader-rate-limit']
+        signatures: ['rate-limit-exhausted']
       },
       { skill: 'maplibre-fonts-glyphs', verdict: 'pass', signatures: [] }
     ]);
@@ -325,8 +322,21 @@ describe('headlineFor', () => {
       ]
     };
     assert.equal(
-      headlineFor({ summary: partial, evalResult: 'cancelled' }),
+      headlineFor({ summary: partial, evalResult: 'failure' }),
       'cut off by the time bound'
+    );
+  });
+
+  it('says cancelled when the job itself was stopped mid-run', () => {
+    const partial = {
+      ...PASSING,
+      configs: [
+        { skill: 'maplibre-cartography', verdict: 'pass', signatures: [] }
+      ]
+    };
+    assert.equal(
+      headlineFor({ summary: partial, evalResult: 'cancelled' }),
+      'cancelled before finishing'
     );
   });
 
@@ -336,7 +346,7 @@ describe('headlineFor', () => {
       {
         skill: 'maplibre-fonts-glyphs',
         verdict: 'error',
-        signatures: ['generator-queue-timeout']
+        signatures: ['queue-timeout']
       }
     ]);
     assert.equal(headlineFor({ summary, evalResult: 'failure' }), 'mixed');
@@ -344,7 +354,7 @@ describe('headlineFor', () => {
 
   it('calls an all-pass record with a non-success job infrastructure', () => {
     assert.equal(
-      headlineFor({ summary: PASSING, evalResult: 'cancelled' }),
+      headlineFor({ summary: PASSING, evalResult: 'failure' }),
       'infrastructure'
     );
   });
@@ -357,7 +367,7 @@ describe('classificationBlock', () => {
       {
         skill: 'maplibre-fonts-glyphs',
         verdict: 'error',
-        signatures: ['generator-queue-timeout'],
+        signatures: ['queue-timeout'],
         tokenUsage: { total: 12000 }
       }
     ]);
@@ -370,7 +380,7 @@ describe('classificationBlock', () => {
     assert.match(block, /\| maplibre-cartography \| pass \|/);
     assert.match(
       block,
-      /\| maplibre-fonts-glyphs \| error \| generator-queue-timeout \|/
+      /\| maplibre-fonts-glyphs \| error \| queue-timeout \|/
     );
     assert.match(block, /2 of 2 planned configs recorded/);
     assert.match(block, /12,000/);

--- a/scripts/github-output.test.js
+++ b/scripts/github-output.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setOutputs } from './lib/github-output.js';
+
+function outputFile() {
+  return join(mkdtempSync(join(tmpdir(), 'github-output-')), 'out');
+}
+
+describe('setOutputs', () => {
+  it('writes a single-line value as key=value', () => {
+    const file = outputFile();
+    setOutputs({ changed: 'true', partial: false }, file);
+    assert.equal(readFileSync(file, 'utf8'), 'changed=true\npartial=false\n');
+  });
+
+  it('appends rather than replacing, as $GITHUB_OUTPUT expects', () => {
+    const file = outputFile();
+    setOutputs({ name: '2026-09-06' }, file);
+    setOutputs({ changed: 'true' }, file);
+    assert.equal(readFileSync(file, 'utf8'), 'name=2026-09-06\nchanged=true\n');
+  });
+
+  it('wraps a multi-line value in a heredoc the runner can read back', () => {
+    const file = outputFile();
+    setOutputs({ summary: 'a: verified -> provisional\nb: pass' }, file);
+    assert.equal(
+      readFileSync(file, 'utf8'),
+      [
+        'summary<<GITHUB_OUTPUT_EOF',
+        'a: verified -> provisional',
+        'b: pass',
+        'GITHUB_OUTPUT_EOF',
+        ''
+      ].join('\n')
+    );
+  });
+
+  it('refuses a value that would close its own heredoc', () => {
+    const file = outputFile();
+    assert.throws(
+      () => setOutputs({ summary: 'one\nGITHUB_OUTPUT_EOF\ntwo' }, file),
+      /delimiter/
+    );
+  });
+});

--- a/scripts/lib/eval-verdicts.js
+++ b/scripts/lib/eval-verdicts.js
@@ -1,0 +1,265 @@
+/**
+ * The vocabulary the weekly eval run reports in: `pass`, `fail`, and `error`.
+ *
+ * `pass` and `fail` are the author's original pair and keep their meaning — a
+ * graded verdict on skill content. `error` is new and means "no verdict": the
+ * provider, the judge, or the run's own time bound stopped the config before it
+ * could answer. Only `pass` and `fail` ever move a skill's `status:` field.
+ *
+ * The shapes read here are those of the installed promptfoo 0.122.0:
+ *
+ *   - `promptfoo eval --output x.json` writes
+ *     `{ evalId, results: <EvaluateSummary>, config, shareableUrl, metadata }`
+ *     — `createOutputData` in node_modules/promptfoo/dist/src/util-BA1y4Bfi.js:3797,
+ *     via `writeJsonOutputSafely` (same file, :3856) from `writeOutput` (:3872).
+ *   - That `results` value is the version-3 summary
+ *     `{ version: 3, timestamp, prompts, results: [...], stats }` —
+ *     `Eval.toEvaluateSummary` in node_modules/promptfoo/dist/src/eval-CMF40G1V.js:1380,
+ *     with `stats` from `getStats` (same file, :1362): `successes`, `failures`,
+ *     `errors`, `tokenUsage`, `durationMs`.
+ *   - Each row carries `error` and `failureReason` —
+ *     `EvalResult.toEvaluateResult` in
+ *     node_modules/promptfoo/dist/src/evalResult-Dnh5pjl7.js:1041.
+ *   - `ResultFailureReason` is `{ NONE: 0, ASSERT: 1, ERROR: 2 }` —
+ *     node_modules/promptfoo/dist/src/tables-DxaDlQbd.js:3566.
+ *
+ * So the rows are at `sidecar.results.results`, not at `sidecar.results`. Any
+ * other shape throws: a classifier that guessed would report a green week it
+ * never checked.
+ */
+import { readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+const NONE = 0;
+const ASSERT = 1;
+const ERROR = 2;
+
+// Signatures a config's verdict can carry. The first four come from the failure
+// text in the run log of 2026-08-30; the last three are the runner's own.
+const CUT_OFF_SIGNATURES = new Set(['max-duration', 'not-run', 'killed']);
+
+/** Every skill's eval config, sorted, template excluded. */
+export function listEvalConfigs(dir = 'evals/prompts') {
+  // Globbing rather than a hardcoded list: a new skill is covered the moment
+  // its config lands.
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.yaml') && name !== 'TEMPLATE.yaml')
+    .sort()
+    .map((name) => join(dir, name));
+}
+
+/** `evals/prompts/maplibre-cartography.yaml` -> `maplibre-cartography`. */
+export function skillOf(configPath) {
+  return basename(configPath, '.yaml');
+}
+
+/** The dated prefix every output file of one run shares. */
+export function runName(date, baseline) {
+  return baseline ? `baseline-${date}` : String(date);
+}
+
+/**
+ * Names the cause behind an ERROR row, so the issue can say what happened
+ * instead of listing what to rule out. Order matters: the judge's rate-limit
+ * message contains the generator's phrase too, so it is matched first.
+ */
+export function signatureOf(message) {
+  const text = String(message ?? '');
+  if (/Evaluation exceeded max duration/.test(text)) return 'max-duration';
+  if (/RateLimitExhaustedError/.test(text)) return 'grader-rate-limit';
+  if (/timed out after \d+ms in queue/.test(text)) {
+    return 'generator-queue-timeout';
+  }
+  if (/\b429\b/.test(text) || /Rate limit exceeded/.test(text)) {
+    return 'generator-rate-limit';
+  }
+  return 'other';
+}
+
+/**
+ * One config's verdict, read from its JSON sidecar.
+ *
+ * Any ERROR row makes the whole config an `error`, even alongside a genuine
+ * assertion failure: a run that was rate-limited has not graded the content, so
+ * it gets no say over a skill's status. That is deliberately conservative — a
+ * real regression in a rate-limited week waits a week to be seen.
+ */
+export function classifyEval(sidecar) {
+  const summary = sidecar?.results;
+  const rows = summary?.results;
+  if (!Array.isArray(rows)) {
+    throw new Error(
+      'Unexpected promptfoo output: no results array at results.results'
+    );
+  }
+  if (rows.length === 0) {
+    throw new Error('Unexpected promptfoo output: no results rows');
+  }
+
+  const counts = { pass: 0, fail: 0, error: 0 };
+  const errors = [];
+  const signatures = [];
+
+  for (const [index, row] of rows.entries()) {
+    const reason = row?.failureReason;
+    if (reason !== NONE && reason !== ASSERT && reason !== ERROR) {
+      throw new Error(
+        `Unexpected promptfoo output: failureReason ${JSON.stringify(reason)} on row ${index}`
+      );
+    }
+    if (reason === NONE) counts.pass++;
+    if (reason === ASSERT) counts.fail++;
+    if (reason === ERROR) {
+      counts.error++;
+      const message = row.error ?? '';
+      const signature = signatureOf(message);
+      if (!signatures.includes(signature)) signatures.push(signature);
+      errors.push({
+        description: row.description ?? `test ${row.testIdx ?? index}`,
+        signature,
+        message
+      });
+    }
+  }
+
+  let verdict = 'pass';
+  if (counts.fail > 0) verdict = 'fail';
+  if (counts.error > 0) verdict = 'error';
+
+  return {
+    verdict,
+    counts,
+    total: rows.length,
+    errors,
+    signatures,
+    tokenUsage: summary.stats?.tokenUsage ?? null
+  };
+}
+
+/**
+ * The verdicts file, strictly. A line that does not parse is a bug in whoever
+ * wrote it, so it stops the sync rather than being skipped: a silently dropped
+ * line reads as "no verdict for that skill" and looks like a clean week.
+ */
+export function parseVerdicts(text) {
+  const verdicts = new Map();
+  for (const raw of String(text ?? '').split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const match = /^([^:\s]+):(pass|fail|error)$/.exec(line);
+    if (!match) throw new Error(`Unparseable verdict line: "${line}"`);
+    verdicts.set(match[1], match[2]);
+  }
+  return verdicts;
+}
+
+/** Expected skills with no line of their own — the run did not reach them. */
+export function missingVerdicts(verdicts, expected) {
+  return expected.filter((skill) => !verdicts.has(skill));
+}
+
+function isCutOff(config) {
+  return (config.signatures ?? []).some((s) => CUT_OFF_SIGNATURES.has(s));
+}
+
+/**
+ * One phrase for what this run was. Read from the run's own record, so it says
+ * what happened rather than asking the reader to guess between infrastructure,
+ * noise, and drift.
+ */
+export function headlineFor({ summary, evalResult }) {
+  if (!summary) return 'cancelled before results';
+  const configs = summary.configs ?? [];
+  const planned = summary.planned ?? [];
+  const failed = configs.some((c) => c.verdict === 'fail');
+  const errored = configs.some((c) => c.verdict === 'error');
+  const cutOff = configs.some(isCutOff) || configs.length < planned.length;
+
+  if (failed && errored) return 'mixed';
+  if (failed) return 'graded failure';
+  if (cutOff) return 'cut off by the time bound';
+  // Everything recorded either passed or errored, and the job still did not
+  // succeed: whatever went wrong was not a graded verdict on skill content.
+  return evalResult === 'success' ? 'graded failure' : 'infrastructure';
+}
+
+function thousands(value) {
+  return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function publishLines(publish = {}) {
+  const commit =
+    publish.commit === 'success'
+      ? 'committed'
+      : publish.commit === 'failure'
+        ? 'not committed: push rejected or the commit step failed'
+        : 'did not run';
+  const sync =
+    publish.sync === 'success'
+      ? publish.partial === true || publish.partial === 'true'
+        ? 'ran (partial: at least one skill had no verdict)'
+        : 'ran'
+      : publish.sync === 'failure'
+        ? 'failed'
+        : 'did not run';
+  const statusCommit =
+    publish.statusCommit === 'success'
+      ? 'committed'
+      : publish.statusCommit === 'failure'
+        ? 'not committed: push rejected or the commit step failed'
+        : 'did not run';
+  return [
+    `- Results CSVs: ${commit}.`,
+    `- Status sync: ${sync}.`,
+    `- Status commit: ${statusCommit}.`
+  ];
+}
+
+/** The markdown that heads the drift issue: the verdict, then the evidence. */
+export function classificationBlock({ summary, evalResult, publish }) {
+  const headline = headlineFor({ summary, evalResult });
+  const lines = [
+    `**Classification: ${headline}.** The \`eval\` job finished with result \`${evalResult || 'unknown'}\`.`,
+    ''
+  ];
+
+  if (!summary) {
+    lines.push(
+      'No summary.json reached the publish job, so no config finished and no verdict exists for any skill.',
+      ''
+    );
+  } else {
+    const configs = summary.configs ?? [];
+    const planned = summary.planned ?? [];
+    const bySkill = new Map(configs.map((c) => [c.skill, c]));
+    lines.push('| Skill | Verdict | Signals |', '| --- | --- | --- |');
+    for (const skill of planned.length > 0
+      ? planned
+      : configs.map((c) => c.skill)) {
+      const config = bySkill.get(skill);
+      const verdict = config?.verdict ?? 'not recorded';
+      const signals = config?.signatures?.length
+        ? config.signatures.join(', ')
+        : '—';
+      lines.push(`| ${skill} | ${verdict} | ${signals} |`);
+    }
+    const tokens = configs.reduce(
+      (total, c) => total + (c.tokenUsage?.total ?? 0),
+      0
+    );
+    lines.push(
+      '',
+      `${configs.length} of ${planned.length} planned configs recorded${
+        tokens > 0 ? `, ${thousands(tokens)} tokens used` : ''
+      }.`,
+      ''
+    );
+  }
+
+  lines.push(
+    ...publishLines(publish),
+    '',
+    "An `error` verdict is not a graded result, so it never changes a skill's `status:` field — see `scripts/sync-skill-status.js`."
+  );
+  return lines.join('\n');
+}

--- a/scripts/lib/eval-verdicts.js
+++ b/scripts/lib/eval-verdicts.js
@@ -60,18 +60,20 @@ export function runName(date, baseline) {
 
 /**
  * Names the cause behind an ERROR row, so the issue can say what happened
- * instead of listing what to rule out. Order matters: the judge's rate-limit
- * message contains the generator's phrase too, so it is matched first.
+ * instead of listing what to rule out. The names carry no provider: promptfoo
+ * raises RateLimitExhaustedError for the generator and the judge alike, and the
+ * row's message still names which one. Order matters: that message contains
+ * the bare "Rate limit exceeded" phrase too, so it is matched first.
  */
 export function signatureOf(message) {
   const text = String(message ?? '');
   if (/Evaluation exceeded max duration/.test(text)) return 'max-duration';
-  if (/RateLimitExhaustedError/.test(text)) return 'grader-rate-limit';
+  if (/RateLimitExhaustedError/.test(text)) return 'rate-limit-exhausted';
   if (/timed out after \d+ms in queue/.test(text)) {
-    return 'generator-queue-timeout';
+    return 'queue-timeout';
   }
   if (/\b429\b/.test(text) || /Rate limit exceeded/.test(text)) {
-    return 'generator-rate-limit';
+    return 'rate-limit';
   }
   return 'other';
 }
@@ -177,6 +179,9 @@ export function headlineFor({ summary, evalResult }) {
 
   if (failed && errored) return 'mixed';
   if (failed) return 'graded failure';
+  // The job itself was stopped — the backstop, or a person — so what the
+  // per-config bound did is beside the point.
+  if (evalResult === 'cancelled') return 'cancelled before finishing';
   if (cutOff) return 'cut off by the time bound';
   // Everything recorded either passed or errored, and the job still did not
   // succeed: whatever went wrong was not a graded verdict on skill content.

--- a/scripts/lib/github-output.js
+++ b/scripts/lib/github-output.js
@@ -1,9 +1,22 @@
 import { appendFileSync } from 'node:fs';
 
+// A value with a newline in it has to be written as a heredoc; `key=value` would
+// leave the runner reading only its first line.
+const DELIMITER = 'GITHUB_OUTPUT_EOF';
+
 // Writes key=value pairs to $GITHUB_OUTPUT (or stdout when unset, for local runs).
 export function setOutputs(outputs, file = process.env.GITHUB_OUTPUT) {
   const lines = Object.entries(outputs)
-    .map(([k, v]) => `${k}=${String(v)}\n`)
+    .map(([k, v]) => {
+      const value = String(v);
+      if (!value.includes('\n')) return `${k}=${value}\n`;
+      if (value.includes(DELIMITER)) {
+        throw new Error(
+          `Output "${k}" contains the heredoc delimiter ${DELIMITER}`
+        );
+      }
+      return `${k}<<${DELIMITER}\n${value}\n${DELIMITER}\n`;
+    })
     .join('');
   if (file) appendFileSync(file, lines);
   else process.stdout.write(lines);

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -44,6 +44,7 @@ import {
   appendFileSync,
   mkdirSync,
   readFileSync,
+  rmSync,
   writeFileSync
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -298,16 +299,17 @@ export async function runEvals({
       log(
         `${skill}: running with a ${Math.round(bound.boundMs / 60000)}-minute bound.`
       );
+      // A sidecar left by an earlier run must not stand in for one the child
+      // never wrote.
+      const sidecarPath = join(workDir, `${name}-${skill}.json`);
+      rmSync(sidecarPath, { force: true });
       const outcome = await spawn(command, args, {
         env: childEnv({ boundMs: bound.boundMs, env }),
         killAfterMs: bound.boundMs + KILL_GRACE_MS
       });
       let sidecarText = null;
       try {
-        sidecarText = readFileSync(
-          join(workDir, `${name}-${skill}.json`),
-          'utf8'
-        );
+        sidecarText = readFileSync(sidecarPath, 'utf8');
       } catch {
         sidecarText = null;
       }

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+/**
+ * Runs the eval configs the weekly drift check covers, one bounded child per
+ * config, and leaves a complete record whatever happens.
+ *
+ * The bound is promptfoo's own: `PROMPTFOO_MAX_EVAL_TIME_MS` arms a global timer
+ * (`getMaxEvalTimeMs`, node_modules/promptfoo/dist/src/logger-B9f-j62Q.js:126,
+ * read at node_modules/promptfoo/dist/src/evaluator-SSlcaq_U.js:8950), and on
+ * expiry every unprocessed test becomes an ERROR row reading "Evaluation
+ * exceeded max duration of Nms" (`createMaxDurationTimeoutResult`, same file,
+ * :8196) before the eval finalizes and writes its outputs. A job-level kill
+ * writes nothing at all, which is how the 2026-08-30 run ended with six hours
+ * spent and no evidence of what happened.
+ *
+ * Each config asks for two output files: the dated CSV the publish job commits,
+ * and a JSON sidecar in the work dir that carries the failure reason behind each
+ * row (`-o, --output <paths...>` is variadic, node_modules/promptfoo/dist/src/main.js:4908,
+ * and both are written before the exit code is set, :4787 then :4845). The CSV's
+ * ERROR rows have an empty output and an empty grader reason, so the sidecar is
+ * the only place the error text survives.
+ *
+ * After every config it appends `skill:pass|fail|error` to `<work>/verdicts.txt`
+ * and rewrites `<work>/summary.json`, so a run cut off halfway still hands the
+ * publish job a record it can report.
+ *
+ *   node scripts/run-evals.js --dry-run
+ *   node scripts/run-evals.js evals/prompts/maplibre-cartography.yaml
+ *
+ * Exit status is 1 when any config did not pass.
+ *
+ * Flags:
+ *   --baseline           withhold the skill (--var injectSkill=false)
+ *   --dry-run            print the commands and the bounds; run nothing
+ *   --results-dir <d>    where the dated CSVs go (default evals/results)
+ *   --work-dir <d>       where the sidecars, verdicts, and summary go
+ *   --config-dir <d>     where the eval configs live (default evals/prompts)
+ *
+ * Env: EVAL_CONFIG_MINUTES, EVAL_BUDGET_MINUTES, EVAL_WORK_DIR, INPUT_CONFIGS,
+ * INPUT_BASELINE. The workflow sets the two bounds in YAML so they are visible
+ * and tunable there; the defaults here match.
+ */
+import { spawn as spawnChild } from 'node:child_process';
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  classifyEval,
+  listEvalConfigs,
+  runName,
+  skillOf
+} from './lib/eval-verdicts.js';
+import { setOutputs } from './lib/github-output.js';
+
+const CONFIG_MINUTES_DEFAULT = 30;
+const BUDGET_MINUTES_DEFAULT = 240;
+
+// Below this there is no point starting a config: promptfoo's own queue timeout
+// is 300s, so a shorter slice buys ERROR rows and nothing else.
+const MIN_CONFIG_MS = 5 * 60000;
+
+// The bound is soft — promptfoo's queue timeout and its backoff sleeps do not
+// honor the abort — so a hard kill follows it. That kill loses the config's CSV,
+// which is why it sits well past the bound rather than on it.
+const KILL_GRACE_MS = 10 * 60000;
+
+export function parseArgs(argv) {
+  const args = { baseline: false, dryRun: false, configs: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--baseline') args.baseline = true;
+    else if (arg === '--dry-run') args.dryRun = true;
+    else if (arg === '--results-dir') args.resultsDir = argv[++i];
+    else if (arg === '--work-dir') args.workDir = argv[++i];
+    else if (arg === '--config-dir') args.configDir = argv[++i];
+    else if (arg.startsWith('--')) {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(1);
+    } else args.configs.push(arg);
+  }
+  return args;
+}
+
+/**
+ * The unchanged `npm run eval:graded` call, with the second output path added.
+ * Never combine configs into one invocation: promptfoo merges the defaultTest
+ * blocks of combined configs (last one wins), which would inject a single
+ * skill's SKILL.md into every test.
+ */
+export function buildCommand({
+  config,
+  name,
+  resultsDir,
+  workDir,
+  baseline = false
+}) {
+  const skill = skillOf(config);
+  return {
+    command: 'npm',
+    args: [
+      'run',
+      'eval:graded',
+      '--',
+      '--config',
+      config,
+      ...(baseline ? ['--var', 'injectSkill=false'] : []),
+      '--output',
+      join(resultsDir, `${name}-${skill}.csv`),
+      join(workDir, `${name}-${skill}.json`)
+    ]
+  };
+}
+
+export function childEnv({ boundMs, env = process.env }) {
+  return { ...env, PROMPTFOO_MAX_EVAL_TIME_MS: String(boundMs) };
+}
+
+/** How long this config may take: the cap, or whatever budget is left. */
+export function boundFor({ elapsedMs, budgetMs, capMs }) {
+  const remaining = budgetMs - elapsedMs;
+  if (remaining < MIN_CONFIG_MS) return { skip: true, boundMs: 0 };
+  return { skip: false, boundMs: Math.min(capMs, remaining) };
+}
+
+/**
+ * One config's verdict from what the child left behind. A sidecar that is
+ * missing, unparseable, or not shaped like promptfoo's output is an `error` —
+ * "no verdict" — and never a pass or a fail, so an unread run cannot move a
+ * skill's status in either direction.
+ */
+export function verdictFor({
+  exitCode = null,
+  killed = false,
+  sidecarText = null
+}) {
+  const base = { counts: null, total: 0, errors: [], tokenUsage: null };
+  if (killed) {
+    return {
+      ...base,
+      verdict: 'error',
+      signatures: ['killed'],
+      reason: 'killed after the hard timeout; promptfoo wrote no output'
+    };
+  }
+  if (sidecarText === null || sidecarText === undefined) {
+    return {
+      ...base,
+      verdict: 'error',
+      signatures: ['no-output'],
+      reason: `no JSON output was written (exit ${exitCode})`
+    };
+  }
+  let sidecar;
+  try {
+    sidecar = JSON.parse(sidecarText);
+  } catch (error) {
+    return {
+      ...base,
+      verdict: 'error',
+      signatures: ['no-output'],
+      reason: `the JSON output could not be parsed: ${error.message}`
+    };
+  }
+  try {
+    const classified = classifyEval(sidecar);
+    return { ...classified, reason: null };
+  } catch (error) {
+    return {
+      ...base,
+      verdict: 'error',
+      signatures: ['no-output'],
+      reason: `unreadable promptfoo output: ${error.message}`
+    };
+  }
+}
+
+function spawnEval(command, args, { env, killAfterMs }) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const child = spawnChild(command, args, { stdio: 'inherit', env });
+    let settled = false;
+    let killed = false;
+    const timer = setTimeout(() => {
+      killed = true;
+      child.kill('SIGTERM');
+    }, killAfterMs);
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ ...result, killed, durationMs: Date.now() - started });
+    };
+    child.on('close', (code) => finish({ exitCode: code }));
+    child.on('error', (error) =>
+      finish({ exitCode: null, spawnError: error.message })
+    );
+  });
+}
+
+export function dryRunLines({
+  configs,
+  name,
+  baseline,
+  resultsDir,
+  workDir,
+  capMinutes,
+  budgetMinutes
+}) {
+  const capMs = capMinutes * 60000;
+  const lines = [
+    `Run name: ${name}`,
+    `Bounds: ${capMinutes} minutes per config, ${budgetMinutes} minutes for the run.`,
+    `Verdicts: ${join(workDir, 'verdicts.txt')}; summary: ${join(workDir, 'summary.json')}`,
+    ''
+  ];
+  for (const config of configs) {
+    const { args } = buildCommand({
+      config,
+      name,
+      resultsDir,
+      workDir,
+      baseline
+    });
+    lines.push(`PROMPTFOO_MAX_EVAL_TIME_MS=${capMs} npm ${args.join(' ')}`);
+  }
+  return lines;
+}
+
+export async function runEvals({
+  configs,
+  name,
+  baseline = false,
+  resultsDir,
+  workDir,
+  capMinutes = CONFIG_MINUTES_DEFAULT,
+  budgetMinutes = BUDGET_MINUTES_DEFAULT,
+  env = process.env,
+  spawn = spawnEval,
+  now = () => Date.now(),
+  log = console.log
+}) {
+  mkdirSync(resultsDir, { recursive: true });
+  mkdirSync(workDir, { recursive: true });
+  const verdictsPath = join(workDir, 'verdicts.txt');
+  const summaryPath = join(workDir, 'summary.json');
+  writeFileSync(verdictsPath, '');
+
+  const capMs = capMinutes * 60000;
+  const budgetMs = budgetMinutes * 60000;
+  const summary = {
+    name,
+    baseline,
+    bounds: { configMinutes: capMinutes, budgetMinutes },
+    planned: configs.map(skillOf),
+    configs: []
+  };
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+
+  const started = now();
+  for (const config of configs) {
+    const skill = skillOf(config);
+    const bound = boundFor({
+      elapsedMs: now() - started,
+      budgetMs,
+      capMs
+    });
+
+    let record;
+    if (bound.skip) {
+      log(
+        `${skill}: not run — the ${budgetMinutes}-minute run budget is spent.`
+      );
+      record = {
+        skill,
+        config,
+        verdict: 'error',
+        counts: null,
+        total: 0,
+        signatures: ['not-run'],
+        reason: 'not-run: budget exhausted',
+        durationMs: 0,
+        exitCode: null,
+        tokenUsage: null
+      };
+    } else {
+      const { command, args } = buildCommand({
+        config,
+        name,
+        resultsDir,
+        workDir,
+        baseline
+      });
+      log(
+        `${skill}: running with a ${Math.round(bound.boundMs / 60000)}-minute bound.`
+      );
+      const outcome = await spawn(command, args, {
+        env: childEnv({ boundMs: bound.boundMs, env }),
+        killAfterMs: bound.boundMs + KILL_GRACE_MS
+      });
+      let sidecarText = null;
+      try {
+        sidecarText = readFileSync(
+          join(workDir, `${name}-${skill}.json`),
+          'utf8'
+        );
+      } catch {
+        sidecarText = null;
+      }
+      const verdict = verdictFor({
+        exitCode: outcome.exitCode ?? null,
+        killed: outcome.killed === true,
+        sidecarText
+      });
+      record = {
+        skill,
+        config,
+        verdict: verdict.verdict,
+        counts: verdict.counts,
+        total: verdict.total,
+        signatures: verdict.signatures,
+        reason: verdict.reason ?? outcome.spawnError ?? null,
+        durationMs: outcome.durationMs ?? null,
+        exitCode: outcome.exitCode ?? null,
+        tokenUsage: verdict.tokenUsage ?? null
+      };
+      for (const error of verdict.errors ?? []) {
+        log(`  ${error.signature}: ${error.description} — ${error.message}`);
+      }
+    }
+
+    log(`${skill}: ${record.verdict}`);
+    appendFileSync(verdictsPath, `${skill}:${record.verdict}\n`);
+    summary.configs.push(record);
+    writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+  }
+
+  return { summary, failed: summary.configs.some((c) => c.verdict !== 'pass') };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const args = parseArgs(process.argv.slice(2));
+  const configDir = args.configDir ?? 'evals/prompts';
+  const fromInput = (process.env.INPUT_CONFIGS ?? '')
+    .split(/\s+/)
+    .filter(Boolean);
+  const configs =
+    args.configs.length > 0
+      ? args.configs
+      : fromInput.length > 0
+        ? fromInput
+        : listEvalConfigs(configDir);
+  if (configs.length === 0) {
+    console.error('No eval configs found.');
+    process.exit(1);
+  }
+
+  const baseline = args.baseline || process.env.INPUT_BASELINE === 'true';
+  const name = runName(new Date().toISOString().slice(0, 10), baseline);
+  const resultsDir = args.resultsDir ?? 'evals/results';
+  const workDir =
+    args.workDir ?? process.env.EVAL_WORK_DIR ?? join(tmpdir(), 'eval');
+  const capMinutes = Number(
+    process.env.EVAL_CONFIG_MINUTES || CONFIG_MINUTES_DEFAULT
+  );
+  const budgetMinutes = Number(
+    process.env.EVAL_BUDGET_MINUTES || BUDGET_MINUTES_DEFAULT
+  );
+
+  if (args.dryRun) {
+    console.log(
+      dryRunLines({
+        configs,
+        name,
+        baseline,
+        resultsDir,
+        workDir,
+        capMinutes,
+        budgetMinutes
+      }).join('\n')
+    );
+    process.exit(0);
+  }
+
+  // The publish job names its committed CSVs from this.
+  setOutputs({ name });
+  console.log(`Evaluating: ${configs.join(' ')}`);
+
+  const { failed } = await runEvals({
+    configs,
+    name,
+    baseline,
+    resultsDir,
+    workDir,
+    capMinutes,
+    budgetMinutes
+  });
+  process.exit(failed ? 1 : 0);
+}

--- a/scripts/run-evals.test.js
+++ b/scripts/run-evals.test.js
@@ -1,0 +1,289 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  boundFor,
+  buildCommand,
+  childEnv,
+  dryRunLines,
+  runEvals,
+  verdictFor
+} from './run-evals.js';
+
+function workspace() {
+  const root = mkdtempSync(join(tmpdir(), 'run-evals-'));
+  return {
+    resultsDir: join(root, 'results'),
+    workDir: join(root, 'work')
+  };
+}
+
+function sidecar(rows) {
+  return JSON.stringify({
+    evalId: 'fixture-eval-id',
+    results: {
+      version: 3,
+      timestamp: '2026-09-06T10:17:00.000Z',
+      prompts: [],
+      results: rows,
+      stats: { successes: 0, failures: 0, errors: 0, tokenUsage: { total: 90 } }
+    },
+    config: {}
+  });
+}
+
+function row(failureReason, error) {
+  return {
+    description: 'explicit',
+    failureReason,
+    success: failureReason === 0,
+    testIdx: 0,
+    ...(error === undefined ? {} : { error })
+  };
+}
+
+describe('buildCommand', () => {
+  it('renders the pinned eval:graded call with both output paths', () => {
+    assert.deepEqual(
+      buildCommand({
+        config: 'evals/prompts/maplibre-cartography.yaml',
+        name: '2026-09-06',
+        resultsDir: 'evals/results',
+        workDir: '/tmp/eval',
+        baseline: false
+      }),
+      {
+        command: 'npm',
+        args: [
+          'run',
+          'eval:graded',
+          '--',
+          '--config',
+          'evals/prompts/maplibre-cartography.yaml',
+          '--output',
+          'evals/results/2026-09-06-maplibre-cartography.csv',
+          '/tmp/eval/2026-09-06-maplibre-cartography.json'
+        ]
+      }
+    );
+  });
+
+  it('withholds the skill on a baseline run, and names the files for it', () => {
+    const { args } = buildCommand({
+      config: 'evals/prompts/maplibre-cartography.yaml',
+      name: 'baseline-2026-09-06',
+      resultsDir: 'evals/results',
+      workDir: '/tmp/eval',
+      baseline: true
+    });
+    assert.deepEqual(args.slice(3, 7), [
+      '--config',
+      'evals/prompts/maplibre-cartography.yaml',
+      '--var',
+      'injectSkill=false'
+    ]);
+    assert.ok(
+      args.includes(
+        'evals/results/baseline-2026-09-06-maplibre-cartography.csv'
+      )
+    );
+  });
+});
+
+describe('childEnv', () => {
+  it('carries the ms bound to the child and keeps the rest of the env', () => {
+    const env = childEnv({ boundMs: 1800000, env: { GROQ_API_KEY: 'x' } });
+    assert.equal(env.PROMPTFOO_MAX_EVAL_TIME_MS, '1800000');
+    assert.equal(env.GROQ_API_KEY, 'x');
+  });
+});
+
+describe('boundFor', () => {
+  it('bounds a config at the cap while the budget is wide open', () => {
+    assert.deepEqual(
+      boundFor({ elapsedMs: 0, budgetMs: 240 * 60000, capMs: 30 * 60000 }),
+      { skip: false, boundMs: 30 * 60000 }
+    );
+  });
+
+  it('shrinks the last config to whatever budget is left', () => {
+    assert.deepEqual(
+      boundFor({
+        elapsedMs: 225 * 60000,
+        budgetMs: 240 * 60000,
+        capMs: 30 * 60000
+      }),
+      { skip: false, boundMs: 15 * 60000 }
+    );
+  });
+
+  it('skips a config it cannot give five minutes', () => {
+    assert.equal(
+      boundFor({
+        elapsedMs: 237 * 60000,
+        budgetMs: 240 * 60000,
+        capMs: 30 * 60000
+      }).skip,
+      true
+    );
+    assert.equal(
+      boundFor({ elapsedMs: 0, budgetMs: 0, capMs: 60000 }).skip,
+      true
+    );
+  });
+});
+
+describe('verdictFor', () => {
+  it('passes only when every row passed', () => {
+    const result = verdictFor({
+      exitCode: 0,
+      sidecarText: sidecar([row(0), row(0)])
+    });
+    assert.equal(result.verdict, 'pass');
+    assert.deepEqual(result.counts, { pass: 2, fail: 0, error: 0 });
+    assert.deepEqual(result.tokenUsage, { total: 90 });
+  });
+
+  it('reads a graded failure behind exit 100', () => {
+    const result = verdictFor({
+      exitCode: 100,
+      sidecarText: sidecar([row(0), row(1)])
+    });
+    assert.equal(result.verdict, 'fail');
+  });
+
+  it('reads a provider error even when the process exited 0', () => {
+    const result = verdictFor({
+      exitCode: 0,
+      sidecarText: sidecar([row(0), row(2, 'Rate limit exceeded')])
+    });
+    assert.equal(result.verdict, 'error');
+    assert.deepEqual(result.signatures, ['generator-rate-limit']);
+  });
+
+  it('calls a missing or unreadable sidecar an error, never a pass', () => {
+    const missing = verdictFor({ exitCode: 1, sidecarText: null });
+    assert.equal(missing.verdict, 'error');
+    assert.deepEqual(missing.signatures, ['no-output']);
+
+    const garbage = verdictFor({ exitCode: 0, sidecarText: '{ not json' });
+    assert.equal(garbage.verdict, 'error');
+    assert.deepEqual(garbage.signatures, ['no-output']);
+
+    const wrongShape = verdictFor({ exitCode: 0, sidecarText: '{"a":1}' });
+    assert.equal(wrongShape.verdict, 'error');
+    assert.match(wrongShape.reason, /results/);
+  });
+
+  it('calls a hard-killed config an error', () => {
+    const result = verdictFor({
+      exitCode: null,
+      killed: true,
+      sidecarText: null
+    });
+    assert.equal(result.verdict, 'error');
+    assert.deepEqual(result.signatures, ['killed']);
+  });
+});
+
+describe('runEvals', () => {
+  it('records every config and leaves a complete summary', async () => {
+    const { resultsDir, workDir } = workspace();
+    const spawn = async (command, args) => {
+      const jsonPath = args[args.indexOf('--output') + 2];
+      const skill = jsonPath.includes('cartography') ? 'pass' : 'fail';
+      writeFileSync(
+        jsonPath,
+        sidecar(skill === 'pass' ? [row(0)] : [row(0), row(1)])
+      );
+      return { exitCode: skill === 'pass' ? 0 : 100, durationMs: 1000 };
+    };
+
+    const { summary, failed } = await runEvals({
+      configs: [
+        'evals/prompts/maplibre-cartography.yaml',
+        'evals/prompts/maplibre-fonts-glyphs.yaml'
+      ],
+      name: '2026-09-06',
+      resultsDir,
+      workDir,
+      capMinutes: 30,
+      budgetMinutes: 240,
+      spawn,
+      log: () => {}
+    });
+
+    assert.equal(failed, true);
+    assert.equal(
+      readFileSync(join(workDir, 'verdicts.txt'), 'utf8'),
+      'maplibre-cartography:pass\nmaplibre-fonts-glyphs:fail\n'
+    );
+    const written = JSON.parse(
+      readFileSync(join(workDir, 'summary.json'), 'utf8')
+    );
+    assert.deepEqual(written.planned, [
+      'maplibre-cartography',
+      'maplibre-fonts-glyphs'
+    ]);
+    assert.equal(written.configs.length, 2);
+    assert.equal(written.configs[1].verdict, 'fail');
+    assert.equal(written.configs[1].exitCode, 100);
+    assert.deepEqual(summary.planned, written.planned);
+  });
+
+  it('records one not-run error per config when the budget is gone', async () => {
+    const { resultsDir, workDir } = workspace();
+    const spawn = async () => {
+      throw new Error('the runner must not spend quota it has no budget for');
+    };
+
+    const { summary, failed } = await runEvals({
+      configs: [
+        'evals/prompts/maplibre-cartography.yaml',
+        'evals/prompts/maplibre-fonts-glyphs.yaml'
+      ],
+      name: '2026-09-06',
+      resultsDir,
+      workDir,
+      capMinutes: 30,
+      budgetMinutes: 0,
+      spawn,
+      log: () => {}
+    });
+
+    assert.equal(failed, true);
+    assert.equal(
+      readFileSync(join(workDir, 'verdicts.txt'), 'utf8'),
+      'maplibre-cartography:error\nmaplibre-fonts-glyphs:error\n'
+    );
+    assert.equal(summary.configs.length, 2);
+    for (const config of summary.configs) {
+      assert.equal(config.verdict, 'error');
+      assert.deepEqual(config.signatures, ['not-run']);
+      assert.match(config.reason, /budget exhausted/);
+    }
+  });
+});
+
+describe('dryRunLines', () => {
+  it('prints the command, the bound, and both output paths per config', () => {
+    const lines = dryRunLines({
+      configs: ['evals/prompts/maplibre-cartography.yaml'],
+      name: '2026-09-06',
+      baseline: false,
+      resultsDir: 'evals/results',
+      workDir: '/tmp/eval',
+      capMinutes: 30,
+      budgetMinutes: 240
+    });
+    const command = lines.find((line) => line.includes('eval:graded'));
+    assert.match(command, /PROMPTFOO_MAX_EVAL_TIME_MS=1800000/);
+    assert.match(
+      command,
+      /--output evals\/results\/2026-09-06-maplibre-cartography\.csv \/tmp\/eval\/2026-09-06-maplibre-cartography\.json/
+    );
+    assert.ok(lines.some((line) => line.includes('240')));
+  });
+});

--- a/scripts/run-evals.test.js
+++ b/scripts/run-evals.test.js
@@ -160,7 +160,7 @@ describe('verdictFor', () => {
       sidecarText: sidecar([row(0), row(2, 'Rate limit exceeded')])
     });
     assert.equal(result.verdict, 'error');
-    assert.deepEqual(result.signatures, ['generator-rate-limit']);
+    assert.deepEqual(result.signatures, ['rate-limit']);
   });
 
   it('calls a missing or unreadable sidecar an error, never a pass', () => {

--- a/scripts/sync-skill-status.js
+++ b/scripts/sync-skill-status.js
@@ -3,67 +3,126 @@
  * Flips a skill's `status:` frontmatter to match the weekly drift check:
  * provisional -> verified on pass, verified -> provisional on fail.
  *
- * Reads one "skillName:pass" or "skillName:fail" line per skill from the file
- * passed as argv[2] (written by eval.yml's "Run evals" step). Skills with no
- * status field, or status: process, are left alone — this only manages the
- * provisional/verified pair, and only for skills that opted in.
+ * Reads one "skillName:pass", "skillName:fail", or "skillName:error" line per
+ * skill from the file passed as argv[2] (written by scripts/run-evals.js).
+ * Skills with no status field, or status: process, are left alone — this only
+ * manages the provisional/verified pair, and only for skills that opted in.
+ *
+ * `error` means the run reached no verdict for that skill: a provider or judge
+ * failure, the per-config time bound, or a run budget that ran out before the
+ * config started. It never flips a status in either direction, so an unlucky
+ * week cannot demote a skill and cannot promote one either. The cost is
+ * deliberate: a real regression in a rate-limited week waits a week to be seen.
+ *
+ * A skill with an eval config but no line at all is reported as missing and
+ * makes the run `partial`, so a half-finished run is never read as a clean one.
  */
-import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  listEvalConfigs,
+  missingVerdicts,
+  parseVerdicts,
+  skillOf
+} from './lib/eval-verdicts.js';
+import { setOutputs } from './lib/github-output.js';
 
-const verdictsPath = process.argv[2];
-if (!verdictsPath) {
-  console.error('Usage: node scripts/sync-skill-status.js <verdicts-file>');
-  process.exit(1);
+export function syncSkillStatus({
+  verdictsText,
+  expectedSkills = [],
+  skillsDir = 'skills'
+}) {
+  const verdicts = parseVerdicts(verdictsText);
+  const changes = [];
+  const ignored = [];
+
+  for (const [skill, verdict] of verdicts) {
+    const skillFile = join(skillsDir, skill, 'SKILL.md');
+
+    let content;
+    try {
+      content = readFileSync(skillFile, 'utf8');
+    } catch {
+      ignored.push({ skill, reason: 'no SKILL.md found, skipping' });
+      continue;
+    }
+
+    const statusMatch = content.match(/^status:\s*(\S+)/m);
+    if (!statusMatch) continue; // no status field — not opted into auto-sync
+    const status = statusMatch[1];
+    if (status === 'process') continue; // eval-exempt, never auto-flipped
+
+    if (verdict === 'error') {
+      ignored.push({
+        skill,
+        reason:
+          'status left as-is (infrastructure or cut-off, not a graded result)'
+      });
+      continue;
+    }
+
+    let next = null;
+    if (status === 'provisional' && verdict === 'pass') next = 'verified';
+    if (status === 'verified' && verdict === 'fail') next = 'provisional';
+    if (!next) continue;
+
+    writeFileSync(
+      skillFile,
+      content.replace(/^status:\s*\S+/m, `status: ${next}`)
+    );
+    changes.push(`${skill}: ${status} -> ${next}`);
+  }
+
+  return {
+    changes,
+    ignored,
+    missing: missingVerdicts(verdicts, expectedSkills)
+  };
 }
 
-const lines = readFileSync(verdictsPath, 'utf8')
-  .trim()
-  .split('\n')
-  .filter(Boolean);
+/** Let the workflow open a report issue on the changes, and see a partial run. */
+export function outputsFor({ changes, missing }) {
+  return {
+    changed: String(changes.length > 0),
+    partial: String(missing.length > 0),
+    ...(changes.length > 0 ? { summary: changes.join('\n') } : {})
+  };
+}
 
-const changes = [];
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const verdictsPath = process.argv[2];
+  if (!verdictsPath) {
+    console.error('Usage: node scripts/sync-skill-status.js <verdicts-file>');
+    process.exit(1);
+  }
 
-for (const line of lines) {
-  const [skill, verdict] = line.split(':');
-  const skillFile = `skills/${skill}/SKILL.md`;
-
-  let content;
+  let result;
   try {
-    content = readFileSync(skillFile, 'utf8');
-  } catch {
-    console.warn(`⚠️  ${skill}: no SKILL.md found, skipping`);
-    continue;
+    result = syncSkillStatus({
+      verdictsText: readFileSync(verdictsPath, 'utf8'),
+      expectedSkills: listEvalConfigs().map(skillOf)
+    });
+  } catch (error) {
+    console.error(`❌ ${error.message}`);
+    process.exit(1);
   }
 
-  const statusMatch = content.match(/^status:\s*(\S+)/m);
-  if (!statusMatch) continue; // no status field — not opted into auto-sync
-  const status = statusMatch[1];
-  if (status === 'process') continue; // eval-exempt, never auto-flipped
+  for (const change of result.changes) console.log(change);
+  for (const { skill, reason } of result.ignored) {
+    console.log(`⚠️  ${skill}: ${reason}`);
+  }
+  for (const skill of result.missing) {
+    console.log(
+      `::warning::${skill}: no verdict in this run, so its status was not checked.`
+    );
+  }
 
-  let next = null;
-  if (status === 'provisional' && verdict === 'pass') next = 'verified';
-  if (status === 'verified' && verdict === 'fail') next = 'provisional';
-  if (!next) continue;
-
-  writeFileSync(
-    skillFile,
-    content.replace(/^status:\s*\S+/m, `status: ${next}`)
+  console.log(
+    result.changes.length > 0
+      ? `\n${result.changes.length} skill(s) updated.`
+      : '\nNo status changes.'
   );
-  console.log(`${skill}: ${status} -> ${next}`);
-  changes.push(`${skill}: ${status} -> ${next}`);
-}
 
-console.log(
-  changes.length > 0
-    ? `\n${changes.length} skill(s) updated.`
-    : '\nNo status changes.'
-);
-
-// Let the workflow step conditionally open a report issue on the changes.
-if (process.env.GITHUB_OUTPUT) {
-  const out = [`changed=${changes.length > 0}`];
-  if (changes.length > 0) {
-    out.push('summary<<SKILL_STATUS_EOF', ...changes, 'SKILL_STATUS_EOF');
-  }
-  appendFileSync(process.env.GITHUB_OUTPUT, out.join('\n') + '\n');
+  setOutputs(outputsFor(result));
 }

--- a/scripts/sync-skill-status.test.js
+++ b/scripts/sync-skill-status.test.js
@@ -1,0 +1,150 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { outputsFor, syncSkillStatus } from './sync-skill-status.js';
+
+// A skills dir holding one SKILL.md per entry, `status` being the frontmatter
+// field under test — or null for a skill that never opted into auto-sync.
+function skillsDir(skills) {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-status-'));
+  for (const [name, status] of Object.entries(skills)) {
+    mkdirSync(join(dir, name));
+    writeFileSync(
+      join(dir, name, 'SKILL.md'),
+      [
+        '---',
+        `name: ${name}`,
+        'description: A skill. Use when testing.',
+        ...(status === null ? [] : [`status: ${status}`]),
+        '---',
+        '',
+        '# Body'
+      ].join('\n')
+    );
+  }
+  return dir;
+}
+
+function statusOf(dir, name) {
+  const content = readFileSync(join(dir, name, 'SKILL.md'), 'utf8');
+  return content.match(/^status:\s*(\S+)/m)?.[1] ?? null;
+}
+
+describe('syncSkillStatus', () => {
+  it('promotes provisional to verified on a pass', () => {
+    const dir = skillsDir({ 'maplibre-cartography': 'provisional' });
+    const result = syncSkillStatus({
+      verdictsText: 'maplibre-cartography:pass\n',
+      skillsDir: dir
+    });
+    assert.deepEqual(result.changes, [
+      'maplibre-cartography: provisional -> verified'
+    ]);
+    assert.equal(statusOf(dir, 'maplibre-cartography'), 'verified');
+  });
+
+  it('demotes verified to provisional on a graded fail', () => {
+    const dir = skillsDir({ 'maplibre-cartography': 'verified' });
+    const result = syncSkillStatus({
+      verdictsText: 'maplibre-cartography:fail\n',
+      skillsDir: dir
+    });
+    assert.deepEqual(result.changes, [
+      'maplibre-cartography: verified -> provisional'
+    ]);
+    assert.equal(statusOf(dir, 'maplibre-cartography'), 'provisional');
+  });
+
+  it('leaves a status alone on an error, in either direction', () => {
+    const dir = skillsDir({
+      'maplibre-cartography': 'verified',
+      'maplibre-fonts-glyphs': 'provisional'
+    });
+    const result = syncSkillStatus({
+      verdictsText: 'maplibre-cartography:error\nmaplibre-fonts-glyphs:error\n',
+      skillsDir: dir
+    });
+    assert.deepEqual(result.changes, []);
+    assert.equal(statusOf(dir, 'maplibre-cartography'), 'verified');
+    assert.equal(statusOf(dir, 'maplibre-fonts-glyphs'), 'provisional');
+    assert.equal(result.ignored.length, 2);
+    assert.match(result.ignored[0].reason, /not a graded result/);
+  });
+
+  it('never touches a process skill or one with no status field', () => {
+    const dir = skillsDir({
+      'maplibre-writing-evals': 'process',
+      'maplibre-cartography': null
+    });
+    const result = syncSkillStatus({
+      verdictsText: 'maplibre-writing-evals:fail\nmaplibre-cartography:pass\n',
+      skillsDir: dir
+    });
+    assert.deepEqual(result.changes, []);
+    assert.equal(statusOf(dir, 'maplibre-writing-evals'), 'process');
+    assert.equal(statusOf(dir, 'maplibre-cartography'), null);
+  });
+
+  it('reports a verdict naming a skill that has no SKILL.md', () => {
+    const dir = skillsDir({ 'maplibre-cartography': 'verified' });
+    const result = syncSkillStatus({
+      verdictsText: 'maplibre-gone:fail\n',
+      skillsDir: dir
+    });
+    assert.deepEqual(result.changes, []);
+    assert.equal(result.ignored[0].skill, 'maplibre-gone');
+    assert.match(result.ignored[0].reason, /no SKILL\.md/);
+  });
+
+  it('names every expected skill the run never reached', () => {
+    const dir = skillsDir({ 'maplibre-cartography': 'verified' });
+    const result = syncSkillStatus({
+      verdictsText: 'maplibre-cartography:pass\n',
+      expectedSkills: [
+        'maplibre-cartography',
+        'maplibre-fonts-glyphs',
+        'maplibre-tile-sources'
+      ],
+      skillsDir: dir
+    });
+    assert.deepEqual(result.missing, [
+      'maplibre-fonts-glyphs',
+      'maplibre-tile-sources'
+    ]);
+  });
+
+  it('refuses a malformed verdicts file rather than syncing part of it', () => {
+    const dir = skillsDir({ 'maplibre-cartography': 'provisional' });
+    assert.throws(
+      () =>
+        syncSkillStatus({
+          verdictsText: 'maplibre-cartography:pass\nmaplibre-fonts-glyphs\n',
+          skillsDir: dir
+        }),
+      /Unparseable/
+    );
+    assert.equal(statusOf(dir, 'maplibre-cartography'), 'provisional');
+  });
+});
+
+describe('outputsFor', () => {
+  it('marks a run with an unreached skill partial', () => {
+    assert.deepEqual(outputsFor({ changes: [], missing: ['a', 'b'] }), {
+      changed: 'false',
+      partial: 'true'
+    });
+  });
+
+  it('passes the changes on as a multi-line summary', () => {
+    assert.deepEqual(
+      outputsFor({ changes: ['a: verified -> provisional'], missing: [] }),
+      {
+        changed: 'true',
+        partial: 'false',
+        summary: 'a: verified -> provisional'
+      }
+    );
+  });
+});


### PR DESCRIPTION
## What this changes

The weekly drift check has run on its cron once, on 2026-08-30, and produced nothing: no results commit, no status change, no issue. [Run 33306412092](https://github.com/maplibre/maplibre-agent-skills/actions/runs/33306412092):

- The `eval` job hit the 360-minute default limit while Groq queued past its 300 s timeout and the judge exhausted its retries, and ended `cancelled`.
- The `publish` job committed the partial CSVs on the trigger commit; `main` had moved, so the push was rejected.
- Every issue step was skipped: they key on `failure`, and the result was `cancelled`.
- Had the push landed, three `fail` verdicts caused entirely by provider errors would have demoted two `verified` skills.

The fix, one PR:

- `scripts/run-evals.js` replaces the shell loop. Same `npm run eval:graded` per config, plus `PROMPTFOO_MAX_EVAL_TIME_MS` on the child (an overrun finalizes with ERROR rows and still writes outputs) and a JSON sidecar beside the CSV, since CSV ERROR rows carry no error text.
- Each config records `pass`, `fail`, or `error`. `error` is a provider or judge failure, a cut-off, or a config the run budget never reached. It never moves a skill's `status`.
- `scripts/sync-skill-status.js` learns `error`, warns per skill with no verdict, and reports `partial`.
- The `publish` job checks out the branch tip and rebases before each push, as `changelog.yml` does.
- The drift issue fires on any non-success run and opens with a classification (`scripts/eval-issue.js`): headline, per-skill verdicts and error signals, and whether the commits landed. The triage text below it is unchanged.

Bounds: 30 minutes per config, 240 per run, as `env` on the Run evals step; 300-minute job backstop. Healthy configs took 5 to 10 minutes on 08-30; the worst took almost three hours.

Not changed: `package.json`, `evals/prompts/lib/`, the cadence, which configs run. Not exercised: the `publish` job (schedule-only); covered by unit tests, `actionlint`, and the pattern already running in `changelog.yml`. Exercised locally with a one-minute cap on one config: 2 PASS, 2 ERROR rows, both outputs written, verdict `error`. Tests ran locally on Node 20 (`npm test`, 155 passing); `check.yml` does not run them.

## Changelog

Bump: patch
Category: Internal
Entry: `eval.yml`: the weekly run is time-bounded per config and per run, records `error` (never a status flip) for infrastructure failures and cut-offs, publishes on the branch tip, and files a classified issue on any non-success run

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above (no skill or eval config is touched)
- [x] Claims are traceable to a primary source (MapLibre docs, style spec, or CHANGELOG)

Sources: the run log above; promptfoo 0.122.0 as installed, cited by file and line in the code comments; GitHub's docs for `timeout-minutes`, `needs.<job>.result`, and `GITHUB_SHA` on `schedule`.

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

AI-assisted by: Claude Opus 4.6 and Claude Fable 5.1
