### PR TITLE
ci(eval): kill the whole process group when a config overruns, and keep what it wrote

### DIFF
--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -21,12 +21,15 @@
  *
  * The hard kill that backs that bound goes to the child's process group, never
  * to the child alone. `npm run` forwards no signals, so a SIGTERM to the wrapper
- * ends the wrapper and leaves promptfoo running: in the 2026-09-06 run three
- * killed configs kept spending the same Groq and Gemini keys for another two
- * hours, which rate-limited every config that came after them. So the child is
- * spawned `detached` (its own group), signalled as `-pid`, and the group is
- * SIGKILLed if it has not emptied SIGKILL_AFTER_MS later — promptfoo's backoff
- * sleeps do not honor SIGTERM promptly.
+ * ends the wrapper and leaves promptfoo running: the three configs killed in the
+ * 2026-09-06 run outlived their kills by 2h40m (source-wiring), 36 minutes
+ * (terrain-rendering) and 13 minutes (tile-sources), all of them still spending
+ * the same Groq and Gemini keys, which rate-limited every config that came after
+ * them. So the child is spawned `detached` (its own group), signalled as `-pid`,
+ * and the group is SIGKILLed if it has not emptied SIGKILL_AFTER_MS later —
+ * promptfoo's backoff sleeps do not honor SIGTERM promptly. Because a detached
+ * child also survives a Ctrl-C on the runner, SIGINT, SIGTERM and SIGHUP on the
+ * parent SIGKILL the group before the runner exits.
  *
  * After every config it appends `skill:pass|fail|error` to `<work>/verdicts.txt`
  * and rewrites `<work>/summary.json`, so a run cut off halfway still hands the
@@ -56,7 +59,7 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { constants as osConstants, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -83,6 +86,10 @@ const KILL_GRACE_MS = 10 * 60000;
 // promptfoo's backoff sleeps do not honor SIGTERM promptly, and a survivor keeps
 // spending the run's API keys.
 export const SIGKILL_AFTER_MS = 30 * 1000;
+
+// A human abort has to take the group with it: `detached` puts the child
+// outside the terminal's foreground group, so Ctrl-C alone would not reach it.
+const ABORT_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
 
 export function parseArgs(argv) {
   const args = { baseline: false, dryRun: false, configs: [] };
@@ -224,6 +231,12 @@ export function verdictFor({
  * `-pid` reaches every descendant, and the promise is not resolved while that
  * group still has members: SIGKILL follows SIGTERM `sigkillAfterMs` later, and
  * the next config starts only once the group is gone.
+ *
+ * That same detachment takes the child out of the terminal's foreground group,
+ * so a Ctrl-C on the runner no longer reaches it: while a child is live the
+ * runner catches SIGINT, SIGTERM and SIGHUP, SIGKILLs the group — a human abort
+ * has no use for promptfoo's partial output, and SIGTERM would leave it asleep
+ * in backoff — and exits 128 + the signal number.
  */
 export function spawnEval(
   command,
@@ -255,11 +268,23 @@ export function spawnEval(
       }
     };
 
+    const unlisten = () =>
+      ABORT_SIGNALS.forEach((signal) => process.removeListener(signal, abort));
+    function abort(signal) {
+      signalGroup('SIGKILL');
+      unlisten();
+      process.exit(128 + (osConstants.signals[signal] ?? 0));
+    }
+    // No listener outlives its child: finish() takes these off again, so a
+    // runner aborted between configs dies of the signal as it always did.
+    ABORT_SIGNALS.forEach((signal) => process.on(signal, abort));
+
     const finish = () => {
       if (settled || pending === null) return;
       settled = true;
       clearTimeout(timer);
       clearTimeout(escalation);
+      unlisten();
       resolve({ ...pending, killed, durationMs: Date.now() - started });
     };
 

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -19,6 +19,15 @@
  * ERROR rows have an empty output and an empty grader reason, so the sidecar is
  * the only place the error text survives.
  *
+ * The hard kill that backs that bound goes to the child's process group, never
+ * to the child alone. `npm run` forwards no signals, so a SIGTERM to the wrapper
+ * ends the wrapper and leaves promptfoo running: in the 2026-09-06 run three
+ * killed configs kept spending the same Groq and Gemini keys for another two
+ * hours, which rate-limited every config that came after them. So the child is
+ * spawned `detached` (its own group), signalled as `-pid`, and the group is
+ * SIGKILLed if it has not emptied SIGKILL_AFTER_MS later — promptfoo's backoff
+ * sleeps do not honor SIGTERM promptly.
+ *
  * After every config it appends `skill:pass|fail|error` to `<work>/verdicts.txt`
  * and rewrites `<work>/summary.json`, so a run cut off halfway still hands the
  * publish job a record it can report.
@@ -69,6 +78,11 @@ const MIN_CONFIG_MS = 5 * 60000;
 // honor the abort — so a hard kill follows it. That kill loses the config's CSV,
 // which is why it sits well past the bound rather than on it.
 const KILL_GRACE_MS = 10 * 60000;
+
+// How long the process group gets to exit on SIGTERM before it is SIGKILLed:
+// promptfoo's backoff sleeps do not honor SIGTERM promptly, and a survivor keeps
+// spending the run's API keys.
+export const SIGKILL_AFTER_MS = 30 * 1000;
 
 export function parseArgs(argv) {
   const args = { baseline: false, dryRun: false, configs: [] };
@@ -180,25 +194,77 @@ export function verdictFor({
   }
 }
 
-function spawnEval(command, args, { env, killAfterMs }) {
+/**
+ * One `npm run eval:graded` child, killed as a process group when it overruns.
+ *
+ * `npm run` is a wrapper: it spawns a shell, which spawns promptfoo, and it
+ * forwards nothing it receives. Signalling the child alone therefore reaps the
+ * wrapper and orphans the promptfoo process holding the API keys — the whole
+ * 2026-09-06 failure. `detached: true` gives the child its own process group so
+ * `-pid` reaches every descendant, and the promise is not resolved while that
+ * group still has members: SIGKILL follows SIGTERM `sigkillAfterMs` later, and
+ * the next config starts only once the group is gone.
+ */
+export function spawnEval(
+  command,
+  args,
+  { env, killAfterMs, sigkillAfterMs = SIGKILL_AFTER_MS }
+) {
   return new Promise((resolve) => {
     const started = Date.now();
-    const child = spawnChild(command, args, { stdio: 'inherit', env });
+    const child = spawnChild(command, args, {
+      stdio: 'inherit',
+      env,
+      detached: true
+    });
     let settled = false;
     let killed = false;
-    const timer = setTimeout(() => {
-      killed = true;
-      child.kill('SIGTERM');
-    }, killAfterMs);
-    const finish = (result) => {
-      if (settled) return;
+    let escalated = false;
+    let pending = null;
+    let escalation = null;
+
+    // Signal 0 asks whether the group still has members. ESRCH — an empty group,
+    // or a child that never started — is the answer, not an error.
+    const signalGroup = (signal) => {
+      if (child.pid === undefined) return false;
+      try {
+        process.kill(-child.pid, signal);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const finish = () => {
+      if (settled || pending === null) return;
       settled = true;
       clearTimeout(timer);
-      resolve({ ...result, killed, durationMs: Date.now() - started });
+      clearTimeout(escalation);
+      resolve({ ...pending, killed, durationMs: Date.now() - started });
     };
-    child.on('close', (code) => finish({ exitCode: code }));
+
+    const timer = setTimeout(() => {
+      killed = true;
+      signalGroup('SIGTERM');
+      escalation = setTimeout(() => {
+        escalated = true;
+        signalGroup('SIGKILL');
+        finish();
+      }, sigkillAfterMs);
+    }, killAfterMs);
+
+    const settle = (result) => {
+      pending = result;
+      // The wrapper exits on SIGTERM long before promptfoo does. Hold the result
+      // until the escalation has emptied the group rather than letting the run
+      // move on while the old config still spends the run's quota.
+      if (killed && !escalated && signalGroup(0)) return;
+      finish();
+    };
+
+    child.on('close', (code) => settle({ exitCode: code }));
     child.on('error', (error) =>
-      finish({ exitCode: null, spawnError: error.message })
+      settle({ exitCode: null, spawnError: error.message })
     );
   });
 }

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -147,6 +147,12 @@ export function boundFor({ elapsedMs, budgetMs, capMs }) {
  * missing, unparseable, or not shaped like promptfoo's output is an `error` —
  * "no verdict" — and never a pass or a fail, so an unread run cannot move a
  * skill's status in either direction.
+ *
+ * A killed config is an `error` whatever its rows say, but promptfoo often has
+ * written its sidecar by then (its own PROMPTFOO_MAX_EVAL_TIME_MS timer fires
+ * before the hard kill), and that sidecar names why the config ran long. So the
+ * classified signatures are kept and `killed` is appended to them: the issue
+ * table then reads `rate-limit-exhausted, killed` rather than just `killed`.
  */
 export function verdictFor({
   exitCode = null,
@@ -154,15 +160,15 @@ export function verdictFor({
   sidecarText = null
 }) {
   const base = { counts: null, total: 0, errors: [], tokenUsage: null };
-  if (killed) {
-    return {
-      ...base,
-      verdict: 'error',
-      signatures: ['killed'],
-      reason: 'killed after the hard timeout; promptfoo wrote no output'
-    };
-  }
+  const killedBlind = (why) => ({
+    ...base,
+    verdict: 'error',
+    signatures: ['killed'],
+    reason: `killed after the hard timeout; ${why}`
+  });
+
   if (sidecarText === null || sidecarText === undefined) {
+    if (killed) return killedBlind('promptfoo wrote no output');
     return {
       ...base,
       verdict: 'error',
@@ -174,6 +180,10 @@ export function verdictFor({
   try {
     sidecar = JSON.parse(sidecarText);
   } catch (error) {
+    if (killed)
+      return killedBlind(
+        `the JSON output could not be parsed: ${error.message}`
+      );
     return {
       ...base,
       verdict: 'error',
@@ -183,8 +193,18 @@ export function verdictFor({
   }
   try {
     const classified = classifyEval(sidecar);
-    return { ...classified, reason: null };
+    if (!killed) return { ...classified, reason: null };
+    return {
+      ...classified,
+      verdict: 'error',
+      signatures: classified.signatures.includes('killed')
+        ? classified.signatures
+        : [...classified.signatures, 'killed'],
+      reason: 'killed after the hard timeout; promptfoo had written output'
+    };
   } catch (error) {
+    if (killed)
+      return killedBlind(`unreadable promptfoo output: ${error.message}`);
     return {
       ...base,
       verdict: 'error',

--- a/scripts/run-evals.test.js
+++ b/scripts/run-evals.test.js
@@ -3,13 +3,16 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 import {
   boundFor,
   buildCommand,
   childEnv,
   dryRunLines,
   runEvals,
-  verdictFor
+  spawnEval,
+  verdictFor,
+  SIGKILL_AFTER_MS
 } from './run-evals.js';
 
 function workspace() {
@@ -42,6 +45,56 @@ function row(failureReason, error) {
     testIdx: 0,
     ...(error === undefined ? {} : { error })
   };
+}
+
+/**
+ * A grandchild that outlives its parent shell, the way promptfoo outlives the
+ * `npm run` wrapper: it records its pid and then never exits on its own.
+ */
+function grandchildScript(dir, { ignoreSigterm = false } = {}) {
+  const path = join(dir, 'grandchild.cjs');
+  writeFileSync(
+    path,
+    [
+      ignoreSigterm ? "process.on('SIGTERM', () => {});" : '',
+      "require('node:fs').writeFileSync(process.argv[2], String(process.pid));",
+      'setInterval(() => {}, 1000);',
+      ''
+    ]
+      .filter(Boolean)
+      .join('\n')
+  );
+  return path;
+}
+
+/** `sh -c '<node> script pidfile & wait'` — a wrapper with a child of its own. */
+function wrapperArgs(script, pidFile) {
+  return ['-c', `"${process.execPath}" "${script}" "${pidFile}" & wait`];
+}
+
+async function readPid(pidFile) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      const text = readFileSync(pidFile, 'utf8').trim();
+      if (text) return Number(text);
+    } catch {
+      // not written yet
+    }
+    await sleep(20);
+  }
+  throw new Error('the grandchild never wrote its pid');
+}
+
+async function gone(pid) {
+  for (let attempt = 0; attempt < 150; attempt++) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await sleep(20);
+  }
+  return false;
 }
 
 describe('buildCommand', () => {
@@ -185,6 +238,60 @@ describe('verdictFor', () => {
     });
     assert.equal(result.verdict, 'error');
     assert.deepEqual(result.signatures, ['killed']);
+  });
+});
+
+describe('spawnEval', () => {
+  it('leaves a child that finishes on its own alone', async () => {
+    const result = await spawnEval(
+      process.execPath,
+      ['-e', 'process.exit(3)'],
+      {
+        env: process.env,
+        killAfterMs: 30000
+      }
+    );
+    assert.equal(result.killed, false);
+    assert.equal(result.exitCode, 3);
+    assert.equal(typeof result.durationMs, 'number');
+  });
+
+  it('kills the whole process group, not just the wrapper', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-eval-group-'));
+    const pidFile = join(dir, 'pid');
+    const script = grandchildScript(dir);
+    const pending = spawnEval('sh', wrapperArgs(script, pidFile), {
+      env: process.env,
+      killAfterMs: 500,
+      sigkillAfterMs: 300
+    });
+    const pid = await readPid(pidFile);
+    const result = await pending;
+    assert.equal(result.killed, true);
+    assert.equal(await gone(pid), true, 'the grandchild outlived the kill');
+  });
+
+  it('escalates to SIGKILL when the group ignores SIGTERM', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-eval-escalate-'));
+    const pidFile = join(dir, 'pid');
+    const script = grandchildScript(dir, { ignoreSigterm: true });
+    const pending = spawnEval('sh', wrapperArgs(script, pidFile), {
+      env: process.env,
+      killAfterMs: 500,
+      sigkillAfterMs: 300
+    });
+    const pid = await readPid(pidFile);
+    const result = await pending;
+    assert.equal(result.killed, true);
+    assert.equal(
+      await gone(pid),
+      true,
+      'the SIGTERM-deaf grandchild survived the escalation'
+    );
+  });
+
+  it('gives the group half a minute before the escalation by default', () => {
+    assert.equal(SIGKILL_AFTER_MS, 30000);
   });
 });
 

--- a/scripts/run-evals.test.js
+++ b/scripts/run-evals.test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawn as spawnChild } from 'node:child_process';
+import { once } from 'node:events';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -290,6 +292,9 @@ describe('verdictFor', () => {
 
 describe('spawnEval', () => {
   it('leaves a child that finishes on its own alone', async () => {
+    const abortListeners = () =>
+      ['SIGINT', 'SIGTERM', 'SIGHUP'].map((s) => process.listenerCount(s));
+    const before = abortListeners();
     const result = await spawnEval(
       process.execPath,
       ['-e', 'process.exit(3)'],
@@ -301,6 +306,11 @@ describe('spawnEval', () => {
     assert.equal(result.killed, false);
     assert.equal(result.exitCode, 3);
     assert.equal(typeof result.durationMs, 'number');
+    assert.deepEqual(
+      abortListeners(),
+      before,
+      'an abort listener outlived its child'
+    );
   });
 
   it('kills the whole process group, not just the wrapper', async () => {
@@ -309,7 +319,7 @@ describe('spawnEval', () => {
     const script = grandchildScript(dir);
     const pending = spawnEval('sh', wrapperArgs(script, pidFile), {
       env: process.env,
-      killAfterMs: 500,
+      killAfterMs: 1500,
       sigkillAfterMs: 300
     });
     const pid = await readPid(pidFile);
@@ -324,7 +334,7 @@ describe('spawnEval', () => {
     const script = grandchildScript(dir, { ignoreSigterm: true });
     const pending = spawnEval('sh', wrapperArgs(script, pidFile), {
       env: process.env,
-      killAfterMs: 500,
+      killAfterMs: 1500,
       sigkillAfterMs: 300
     });
     const pid = await readPid(pidFile);
@@ -335,6 +345,29 @@ describe('spawnEval', () => {
       true,
       'the SIGTERM-deaf grandchild survived the escalation'
     );
+  });
+
+  it('takes the group with it when the runner itself is interrupted', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-eval-abort-'));
+    const pidFile = join(dir, 'pid');
+    const script = grandchildScript(dir);
+    const source = [
+      `import { spawnEval } from ${JSON.stringify(new URL('./run-evals.js', import.meta.url).href)};`,
+      `await spawnEval('sh', ${JSON.stringify(wrapperArgs(script, pidFile))}, {`,
+      '  env: process.env,',
+      '  killAfterMs: 60000',
+      '});'
+    ].join('\n');
+    const runner = spawnChild(
+      process.execPath,
+      ['--input-type=module', '-e', source],
+      { stdio: 'inherit' }
+    );
+    const pid = await readPid(pidFile);
+    runner.kill('SIGINT');
+    const [code] = await once(runner, 'close');
+    assert.equal(code, 130, 'the runner should exit 128 + SIGINT');
+    assert.equal(await gone(pid), true, 'Ctrl-C left the grandchild running');
   });
 
   it('gives the group half a minute before the escalation by default', () => {

--- a/scripts/run-evals.test.js
+++ b/scripts/run-evals.test.js
@@ -238,6 +238,53 @@ describe('verdictFor', () => {
     });
     assert.equal(result.verdict, 'error');
     assert.deepEqual(result.signatures, ['killed']);
+    assert.match(result.reason, /wrote no output/);
+  });
+
+  it('keeps the signatures a killed config had already written', () => {
+    const result = verdictFor({
+      exitCode: null,
+      killed: true,
+      sidecarText: sidecar([
+        row(0),
+        row(2, 'RateLimitExhaustedError: judge gave up'),
+        row(2, 'Provider timed out after 300000ms in queue')
+      ])
+    });
+    assert.equal(result.verdict, 'error');
+    assert.deepEqual(result.signatures, [
+      'rate-limit-exhausted',
+      'queue-timeout',
+      'killed'
+    ]);
+    assert.deepEqual(result.counts, { pass: 1, fail: 0, error: 2 });
+    assert.match(result.reason, /killed after the hard timeout/);
+  });
+
+  it('never grades a killed config, however its rows read', () => {
+    const passing = verdictFor({
+      exitCode: null,
+      killed: true,
+      sidecarText: sidecar([row(0), row(0)])
+    });
+    assert.equal(passing.verdict, 'error');
+    assert.deepEqual(passing.signatures, ['killed']);
+
+    const failing = verdictFor({
+      exitCode: null,
+      killed: true,
+      sidecarText: sidecar([row(0), row(1)])
+    });
+    assert.equal(failing.verdict, 'error');
+    assert.deepEqual(failing.signatures, ['killed']);
+
+    const garbage = verdictFor({
+      exitCode: null,
+      killed: true,
+      sidecarText: '{ not json'
+    });
+    assert.equal(garbage.verdict, 'error');
+    assert.deepEqual(garbage.signatures, ['killed']);
   });
 });
 


### PR DESCRIPTION
## What this changes

The weekly run's hard kill did not stop promptfoo. This makes the kill reach the whole process tree and lets a killed config still report what promptfoo wrote.

Closes #91.

What happened on 2026-09-06 ([job log](https://github.com/maplibre/maplibre-agent-skills/actions/runs/34027339593/job/101470548844)):

- `scripts/run-evals.js` sent SIGTERM to the `npm run eval:graded` wrapper; the promptfoo child survived every kill.
- `maplibre-source-wiring` was declared `error` at 11:36 UTC and its `[CI Progress]` stream was still ticking at 159 minutes when the job ended.
- `maplibre-terrain-rendering` outlived its kill by 36 minutes, `maplibre-tile-sources` by 13; three promptfoo processes then shared one Groq key and one Gemini key.
- The log shows Groq 429s from 11:41, `timed out after 300000ms in queue` on six of seven tile-sources generator calls, and ten Gemini `RateLimitExhaustedError … after 4 attempts` grading failures.
- The sidecars the orphans wrote later carried the real signatures (`rate-limit-exhausted`, `queue-timeout`); the issue table said only `killed` because `verdictFor` never reads a sidecar once a config is marked killed.

The fix:

- `spawnEval` starts the child in its own process group (`detached: true`) and kills the group, not the wrapper.
- SIGTERM first; SIGKILL to the group 30 seconds later if it still has members, since promptfoo's backoff sleeps do not honor SIGTERM promptly.
- The run does not move on while the group has members: `npm run` exits on SIGTERM at once, so the child's `close` event alone would have let the next config start beside the survivor.
- A local abort is covered too: `detached` puts the child outside the terminal's foreground group, so while a child is live SIGINT, SIGTERM and SIGHUP on the runner SIGKILL the group and exit 128 + signal.
- `verdictFor` classifies the sidecar of a killed config when one exists: verdict stays `error` (never a graded result), signatures carry the real ones plus `killed`.
- Header comment updated to state the process-group fact.
- Tests (`npm test`, 162 passing): the new `verdictFor` branches; real-process tests that spawn an `sh → node` chain and assert the grandchild is gone after the kill, after the SIGKILL escalation against a SIGTERM-deaf grandchild, and after a Ctrl-C on the runner; a listener-leak check.

Not exercised: the scheduled path itself (needs the repo's secrets); the next Sunday run (2026-09-13 10:17 UTC) is the live test. `eval.yml`, `package.json`, and `evals/prompts/lib/` are unchanged.

## Changelog

Bump: patch
Category: Internal
Entry: `eval.yml`: a config that overruns its bound is now actually stopped (process-group kill with SIGKILL escalation), and a killed config's sidecar still feeds the drift issue's signals

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above (no skill or eval config is touched)
- [x] Claims are traceable to a primary source (MapLibre docs, style spec, or CHANGELOG)

Sources: the job log above; the run's `eval-verdicts` artifact; Node's `child_process` docs on `detached` (the child becomes a process-group leader) and POSIX `kill(2)` on a negative pid; promptfoo 0.122.0 as installed.

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

AI-assisted by: Claude Opus 4.6 and Claude Fable 5.1
