### PR TITLE
ci(eval): validate config and output paths before they reach the shell

### DIFF
--- a/scripts/eval-verdicts.test.js
+++ b/scripts/eval-verdicts.test.js
@@ -7,6 +7,8 @@ import {
   classificationBlock,
   classifyEval,
   headlineFor,
+  isSafeCliPath,
+  isSafeConfigPath,
   listEvalConfigs,
   missingVerdicts,
   parseVerdicts,
@@ -229,6 +231,111 @@ describe('listEvalConfigs', () => {
       join(dir, 'maplibre-cartography.yaml'),
       join(dir, 'maplibre-tile-sources.yaml')
     ]);
+  });
+});
+
+describe('isSafeCliPath', () => {
+  it('accepts the paths this runner actually builds', () => {
+    for (const path of [
+      'evals/prompts/maplibre-cartography.yaml',
+      'evals/results',
+      'evals/results/2026-09-06-maplibre-cartography.csv',
+      '/tmp/eval',
+      '/var/folders/ab/T/eval',
+      '.claude/worktrees/x'
+    ]) {
+      assert.equal(isSafeCliPath(path), true, path);
+    }
+  });
+
+  it('rejects the characters that give a path a second meaning', () => {
+    for (const path of [
+      '',
+      'evals/prompts/$(id).yaml',
+      'a;b',
+      'a b',
+      'a|b',
+      'a&b',
+      'a`b`',
+      'a\\b',
+      "a'b",
+      'a*b',
+      'evals\nprompts'
+    ]) {
+      assert.equal(isSafeCliPath(path), false, JSON.stringify(path));
+    }
+  });
+
+  it('rejects traversal, empty segments, and leading dashes', () => {
+    for (const path of [
+      '../evals',
+      'evals/../x',
+      'evals/./x',
+      '.',
+      '..',
+      '-flag',
+      'evals/-x',
+      '//evals',
+      'evals//x',
+      'evals/'
+    ]) {
+      assert.equal(isSafeCliPath(path), false, JSON.stringify(path));
+    }
+  });
+
+  it('rejects a value that is not a string', () => {
+    for (const value of [undefined, null, 42, {}, ['evals/results']]) {
+      assert.equal(isSafeCliPath(value), false, String(value));
+    }
+  });
+});
+
+describe('isSafeConfigPath', () => {
+  function configDir() {
+    const dir = mkdtempSync(join(tmpdir(), 'safe-config-'));
+    mkdirSync(join(dir, 'sub'));
+    for (const name of [
+      'maplibre-cartography.yaml',
+      'TEMPLATE.yaml',
+      'x.yml',
+      '$(id).yaml'
+    ]) {
+      writeFileSync(join(dir, name), '');
+    }
+    writeFileSync(join(dir, 'sub', 'x.yaml'), '');
+    return dir;
+  }
+
+  it('accepts an existing config file sitting directly in the config dir', () => {
+    const dir = configDir();
+    assert.equal(
+      isSafeConfigPath(join(dir, 'maplibre-cartography.yaml'), dir),
+      true
+    );
+  });
+
+  it('rejects the template, a subdirectory, a missing file, and another dir', () => {
+    const dir = configDir();
+    const other = configDir();
+    assert.equal(isSafeConfigPath(join(dir, 'TEMPLATE.yaml'), dir), false);
+    assert.equal(isSafeConfigPath(join(dir, 'sub', 'x.yaml'), dir), false);
+    assert.equal(isSafeConfigPath(join(dir, 'missing.yaml'), dir), false);
+    assert.equal(
+      isSafeConfigPath(join(other, 'maplibre-cartography.yaml'), dir),
+      false
+    );
+    assert.equal(isSafeConfigPath(dir, dir), false);
+  });
+
+  it('rejects a wrong extension and a directory itself', () => {
+    const dir = configDir();
+    assert.equal(isSafeConfigPath(join(dir, 'x.yml'), dir), false);
+    assert.equal(isSafeConfigPath(join(dir, 'sub'), dir), false);
+  });
+
+  it('rejects a name outside the character rule even when the file exists', () => {
+    const dir = configDir();
+    assert.equal(isSafeConfigPath(join(dir, '$(id).yaml'), dir), false);
   });
 });
 

--- a/scripts/lib/eval-verdicts.js
+++ b/scripts/lib/eval-verdicts.js
@@ -27,8 +27,8 @@
  * other shape throws: a classifier that guessed would report a green week it
  * never checked.
  */
-import { readdirSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { readdirSync, statSync } from 'node:fs';
+import { basename, isAbsolute, join, relative, resolve } from 'node:path';
 
 const NONE = 0;
 const ASSERT = 1;
@@ -46,6 +46,59 @@ export function listEvalConfigs(dir = 'evals/prompts') {
     .filter((name) => name.endsWith('.yaml') && name !== 'TEMPLATE.yaml')
     .sort()
     .map((name) => join(dir, name));
+}
+
+// One `/`-separated path segment: letters, digits, dot, underscore, dash.
+// Everything a shell gives a second meaning — space, quote, `$`, `;`, `|`, `&`,
+// backtick, backslash, parenthesis, glob, newline — is outside it.
+const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Whether a path is plain enough to place in a child process's argv.
+ *
+ * Every segment is a name from the safe set, no segment is `.`, `..`, or empty,
+ * and none starts with a dash, which the receiving command would read as a flag.
+ * A single leading `/` is ordinary — work dirs are absolute (`/tmp/eval`, or
+ * macOS `/var/folders/ab/T/eval`) — and nothing else is allowed.
+ */
+export function isSafeCliPath(p) {
+  if (typeof p !== 'string' || p.length === 0) return false;
+  const segments = p.split('/');
+  if (segments[0] === '') segments.shift();
+  if (segments.length === 0) return false;
+  return segments.every(
+    (segment) =>
+      SAFE_SEGMENT.test(segment) &&
+      segment !== '.' &&
+      segment !== '..' &&
+      !segment.startsWith('-')
+  );
+}
+
+/**
+ * Whether a value names an eval config this repo actually has: a plain path, a
+ * `.yaml` file that is not the template, sitting directly in `configDir`, and
+ * present on disk as a regular file. A name that fails any of those is a typo or
+ * someone else's idea, and either way not something to hand to a runner.
+ */
+export function isSafeConfigPath(config, configDir = 'evals/prompts') {
+  if (!isSafeCliPath(config)) return false;
+  if (!config.endsWith('.yaml')) return false;
+  if (basename(config) === 'TEMPLATE.yaml') return false;
+  const inner = relative(resolve(configDir), resolve(config));
+  if (
+    inner === '' ||
+    inner.startsWith('..') ||
+    isAbsolute(inner) ||
+    inner !== basename(inner)
+  ) {
+    return false;
+  }
+  try {
+    return statSync(config).isFile();
+  } catch {
+    return false;
+  }
 }
 
 /** `evals/prompts/maplibre-cartography.yaml` -> `maplibre-cartography`. */

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -35,6 +35,9 @@
  * and rewrites `<work>/summary.json`, so a run cut off halfway still hands the
  * publish job a record it can report.
  *
+ * Config and output paths are validated before they are placed in the `npm run`
+ * argv, which a shell receives.
+ *
  *   node scripts/run-evals.js --dry-run
  *   node scripts/run-evals.js evals/prompts/maplibre-cartography.yaml
  *
@@ -64,6 +67,8 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   classifyEval,
+  isSafeCliPath,
+  isSafeConfigPath,
   listEvalConfigs,
   runName,
   skillOf
@@ -113,6 +118,10 @@ export function parseArgs(argv) {
  * Never combine configs into one invocation: promptfoo merges the defaultTest
  * blocks of combined configs (last one wins), which would inject a single
  * skill's SKILL.md into every test.
+ *
+ * These args reach a shell through `npm run`; npm quotes them, but the runner
+ * does not rely on that — every path is checked here before it enters argv, so a
+ * hostile or mistyped config name is rejected rather than forwarded.
  */
 export function buildCommand({
   config,
@@ -122,6 +131,24 @@ export function buildCommand({
   baseline = false
 }) {
   const skill = skillOf(config);
+  const csvPath = join(resultsDir, `${name}-${skill}.csv`);
+  const jsonPath = join(workDir, `${name}-${skill}.json`);
+  // The last point before the child process, so this covers every caller.
+  if (!isSafeCliPath(config)) {
+    throw new Error(
+      `Refusing to build a command with an unusable config path: ${JSON.stringify(config)}`
+    );
+  }
+  if (!isSafeCliPath(csvPath)) {
+    throw new Error(
+      `Refusing to build a command with an unusable output path: ${JSON.stringify(csvPath)}`
+    );
+  }
+  if (!isSafeCliPath(jsonPath)) {
+    throw new Error(
+      `Refusing to build a command with an unusable output path: ${JSON.stringify(jsonPath)}`
+    );
+  }
   return {
     command: 'npm',
     args: [
@@ -132,8 +159,8 @@ export function buildCommand({
       config,
       ...(baseline ? ['--var', 'injectSkill=false'] : []),
       '--output',
-      join(resultsDir, `${name}-${skill}.csv`),
-      join(workDir, `${name}-${skill}.json`)
+      csvPath,
+      jsonPath
     ]
   };
 }
@@ -471,6 +498,14 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     console.error('No eval configs found.');
     process.exit(1);
   }
+  const rejected = configs.filter((c) => !isSafeConfigPath(c, configDir));
+  if (rejected.length > 0) {
+    for (const value of rejected) {
+      console.error(`Not an eval config under ${configDir}: ${value}`);
+    }
+    console.error(`Configs must be existing ${configDir}/<skill>.yaml paths.`);
+    process.exit(1);
+  }
 
   const baseline = args.baseline || process.env.INPUT_BASELINE === 'true';
   const name = runName(new Date().toISOString().slice(0, 10), baseline);
@@ -483,6 +518,17 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const budgetMinutes = Number(
     process.env.EVAL_BUDGET_MINUTES || BUDGET_MINUTES_DEFAULT
   );
+
+  const badDirs = [
+    ['--results-dir', resultsDir],
+    ['--work-dir / EVAL_WORK_DIR', workDir]
+  ].filter(([, dir]) => !isSafeCliPath(dir));
+  if (badDirs.length > 0) {
+    for (const [flag, dir] of badDirs) {
+      console.error(`Not a usable ${flag} path: ${dir}`);
+    }
+    process.exit(1);
+  }
 
   if (args.dryRun) {
     console.log(

--- a/scripts/run-evals.test.js
+++ b/scripts/run-evals.test.js
@@ -125,6 +125,41 @@ describe('buildCommand', () => {
     );
   });
 
+  it('refuses a config or output path the shell could read', () => {
+    assert.throws(
+      () =>
+        buildCommand({
+          config: 'evals/prompts/$(id).yaml',
+          name: '2026-09-06',
+          resultsDir: 'evals/results',
+          workDir: '/tmp/eval'
+        }),
+      (error) => error.message.includes('evals/prompts/$(id).yaml')
+    );
+    assert.throws(
+      () =>
+        buildCommand({
+          config: 'evals/prompts/maplibre-cartography.yaml',
+          name: '2026-09-06',
+          resultsDir: 'out dir',
+          workDir: '/tmp/eval'
+        }),
+      (error) =>
+        error.message.includes('out dir/2026-09-06-maplibre-cartography.csv')
+    );
+    assert.throws(
+      () =>
+        buildCommand({
+          config: 'evals/prompts/maplibre-cartography.yaml',
+          name: '2026-09-06',
+          resultsDir: 'evals/results',
+          workDir: 'x y'
+        }),
+      (error) =>
+        error.message.includes('x y/2026-09-06-maplibre-cartography.json')
+    );
+  });
+
   it('withholds the skill on a baseline run, and names the files for it', () => {
     const { args } = buildCommand({
       config: 'evals/prompts/maplibre-cartography.yaml',


### PR DESCRIPTION
## What this changes

The eval runner now checks every path before it goes into the `npm run eval:graded` argv, answering the one open CodeQL alert.

- The flagged call is the `child_process.spawn` call (`spawnChild`) in `spawnEval` (#93). Its argv carries the config path and two output paths, and those come from outside the program: the `configs` dispatch input, the `evals/prompts/` directory listing, CLI positionals, and `EVAL_WORK_DIR` / `--work-dir` / `--results-dir`. `npm run` hands that argv to a shell.
- Exposure as it stood: none that the trust model did not already grant. npm quotes forwarded args (`@npmcli/promise-spawn` `escape.sh`, checked in npm 10.8.2's source and with a live `$(…)` probe that stayed literal), and a dispatch against an unreviewed ref already runs that ref's `package.json` with the secrets (`evals/README.md` → CI). The change is defense in depth, and it turns a mistyped `configs` input into a one-line rejection instead of a failed child recorded as `error` and a drift issue. npm's quoting does not stop a value beginning with `-` from reaching promptfoo as an option; the leading-dash rule does.
- `scripts/lib/eval-verdicts.js`: `isSafeCliPath` (segments of `[A-Za-z0-9._-]`, no `.`/`..`, no leading dash, optional leading `/`) and `isSafeConfigPath` (a `.yaml` that is not `TEMPLATE.yaml`, directly inside the config dir, and an existing regular file).
- `scripts/run-evals.js`: `buildCommand` throws on an unsafe config path or either unsafe output path — the last point before argv, so `runEvals` and `dryRunLines` are both covered; `main()` rejects a config that is not an existing `evals/prompts/<skill>.yaml` and a results or work dir the character rule refuses, before the dry-run branch, naming each offender.
- Tests: 9 new cases in `scripts/eval-verdicts.test.js` and `scripts/run-evals.test.js`; `npm test` green on Node 20.

## The gap it closes

The one open CodeQL alert, `js/shell-command-injection-from-environment` on `scripts/run-evals.js` ([code-scanning/3](https://github.com/maplibre/maplibre-agent-skills/security/code-scanning/3); the link resolves for maintainers only).

Not verifiable before merge: code scanning here analyzes `main` and same-repo branches only (fork PRs such as #93 and #94 get no analysis), so whether the query recognises the guard is only visible on the first `main` scan after this lands; if it does not, the alert is dismissed with the validator as the stated reason. `eval.yml` was not dispatched against this ref; on ubuntu-latest `EVAL_WORK_DIR` resolves to `/home/runner/work/_temp/eval`, which the rule accepts. `eval.yml`, `package.json`, and `evals/prompts/lib/` are unchanged.

## How to review

Read `isSafeCliPath` and `isSafeConfigPath` against the rejects in `scripts/eval-verdicts.test.js`, then the two guard sites in `scripts/run-evals.js`. `node scripts/run-evals.js --dry-run 'evals/prompts/$(id).yaml'` exits 1 with the rejection; `node scripts/run-evals.js --dry-run` prints the usual plan.

## Changelog

Bump: patch
Category: Internal
Entry: `eval.yml`: the runner rejects config and output paths that are not plain `evals/prompts/<skill>.yaml` files or plain directories before they reach `npm run`, answering the CodeQL shell-command alert

## Checks

- [x] `npm run check` passes
- [ ] Evals run, or `status: provisional` set with the gap cited above (no skill or eval config is touched)
- [x] Claims are traceable to a primary source (MapLibre docs, style spec, or CHANGELOG)

Sources: CodeQL query help for `js/shell-command-injection-from-environment`; `@npmcli/promise-spawn` 7.0.2 `lib/index.js` (`escape.sh` on each arg when `shell` is set); Node's `child_process` docs on `shell`.

## AI usage

- [x] No substantial AI-generated content, **or** it is described below (tools, models, prompts), and I have verified every claim against a primary source and can answer questions about it in review.
- [x] I wrote this PR description myself.

AI-assisted by: Claude Opus 4.6 and Claude Fable 5.1
